### PR TITLE
only abort on error when the invaid column is used in inventory file

### DIFF
--- a/xcat-inventory/xcclient/inventory/dbfactory.py
+++ b/xcat-inventory/xcclient/inventory/dbfactory.py
@@ -15,6 +15,13 @@ def create_or_update(session,tabcls,key,newdict,ismatrixtable=True):
     tabcols=tabcls.getcolumns()
 
     for item in newdict.keys():
+        if item not in tabcols:
+            if newdict[item] is None:
+                del newdict[item] 
+                continue
+            else:
+                raise BadSchemaException("Error: no column '"+item+"' in table "+tabcls.__tablename__+", might caused by mismatch between schema version and xCAT version!")
+            
         if  tabkey != item and newdict[item] is not None:
             skiprow=0        
 
@@ -27,10 +34,7 @@ def create_or_update(session,tabcls,key,newdict,ismatrixtable=True):
         if item == 'disable' and newdict[item]=='':
             newdict[item]=None
         
-        if item not in tabcols:
-            print("Warning: no column '"+item+"' in table "+tabcls.__tablename__+", might caused by mismatch between schema version and xCAT version! ignore column '"+item+"' ...")
-            del newdict[item] 
-            
+
 
     if not ismatrixtable:
         if skiprow:


### PR DESCRIPTION
```
[root@c910f03c05k21 ~]# cat /tmp/node0009 |grep consoleenabled
                       "consoleenabled": "11"
[root@c910f03c05k21 ~]# xcat-inventory import -f /tmp/node0009
Importing object: node0009
Error: no column 'mconsoleenabled' in table nodehm, might caused by mismatch between schema version and xCAT version!
[root@c910f03c05k21 ~]# echo $?
1
[root@c910f03c05k21 ~]# xcat-inventory import -f /tmp/node0009
Importing object: node0009
Importing object: xcatdefaults
Inventory import successfully!
```