### PR TITLE
add zone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ xcat-inventory is an inventory tool for the cluster managed by xCAT(http://xcat.
 
 ## installing
 
-Download "xcat-inventory" package from [xcat-inventory](http://xcat.org/files/xcat/xcat-dep/2.x_Linux/beta/xcat-inventory/xcat-inventory-0.1.1-snap201803091036.noarch.rpm) to xCAT management node, and run `yum install xcat-inventory.rpm` to install it
+Download "xcat-inventory" package from [xcat-inventory](http://xcat.org/files/xcat/xcat-dep/2.x_Linux/beta/xcat-inventory/xcat-inventory-0.1.1-snap201803100117.noarch.rpm) to xCAT management node, and run `yum install xcat-inventory.rpm` to install it
 
 ## dependency
 

--- a/xcat-inventory/xcclient/inventory/dbobject.py
+++ b/xcat-inventory/xcclient/inventory/dbobject.py
@@ -356,6 +356,12 @@ class nimimage(Base,mixin):
     __tablename__ = 'nimimage'
     __table_args__ = {'autoload':True}
 ########################################################################
+class zone(Base,mixin):
+    """"""
+    Base.metadata.bind = DBsession.getEngine('zone')
+    __tablename__ = 'zone'
+    __table_args__ = {'autoload':True}
+########################################################################
 class site(Base,mixin):
     """"""
     Base.metadata.bind = DBsession.getEngine('site')

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -23,7 +23,7 @@ VALID_OBJ_FORMAT = ['yaml', 'json']
 
 class InventoryFactory(object):
     __InventoryHandlers__ = {}
-    __InventoryClass__ = {'node': Node, 'network': Network, 'osimage': Osimage, 'route': Route, 'policy': Policy, 'passwd': Passwd,'site': Site}
+    __InventoryClass__ = {'node': Node, 'network': Network, 'osimage': Osimage, 'route': Route, 'policy': Policy, 'passwd': Passwd,'site': Site,'zone':Zone}
     __db__ = None
     
     def __init__(self, objtype,dbsession,schemapath):

--- a/xcat-inventory/xcclient/inventory/schema/1.0/zone.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/zone.yaml
@@ -1,0 +1,6 @@
+!!python/dict
+  zone:
+    sshkeydir: "T{zone.sshkeydir}"
+    sshbetweennodes: "T{zone.sshbetweennodes}"
+    defaultzone: "T{zone.defaultzone}"
+    comments: "T{zone.comments}"


### PR DESCRIPTION
```
[root@c910f03c05k21 xCAT-Incubator]# xcat-inventory export -t zone
{
    "schema_version": "1.0",
    "zone": {
        "aa": {
            "defaultzone": "no",
            "sshbetweennodes": "yes",
            "sshkeydir": "/etc/xcat/sshkeys/aa/.ssh"
        },
        "xcatdefault": {
            "defaultzone": "yes",
            "sshbetweennodes": "yes",
            "sshkeydir": "/root/.ssh"
        }
    }
}

[root@c910f03c05k21 xCAT-Incubator]# xcat-inventory import -f /tmp/zones
Importing object: aa
Importing object: xcatdefault
Inventory import successfully!
```