### PR TITLE
add Zone class

### DIFF
--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -473,5 +473,7 @@ class Passwd(XcatBase):
 class Site(XcatBase):
     _schema_loc__ = os.path.join(os.path.dirname(__file__), 'schema/latest/site.yaml')
 
+class Zone(XcatBase):
+    _schema_loc__ = os.path.join(os.path.dirname(__file__), 'schema/latest/zone.yaml')
 if __name__ == "__main__":
     pass


### PR DESCRIPTION
```
[root@c910f03c05k21 xCAT-Incubator]# xcat-inventory export -t zone
{
    "schema_version": "1.0",
    "zone": {
        "aa": {
            "defaultzone": "no",
            "sshbetweennodes": "yes",
            "sshkeydir": "/etc/xcat/sshkeys/aa/.ssh"
        },
        "xcatdefault": {
            "defaultzone": "yes",
            "sshbetweennodes": "yes",
            "sshkeydir": "/root/.ssh"
        }
    }
}
```