### PR TITLE
fix route.net validation: net might be default

### DIFF
--- a/xcat-inventory/xcclient/inventory/schema/1.0/route.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/route.yaml
@@ -2,7 +2,7 @@
   route:
     net: 
     - "T{routes.net}"
-    - "C:${{value=V{net}: vutil.isIPaddr(value)}}"
+    - "C:${{value=V{net}: True if vutil.isIPaddr(value) or value in ('default') else False}}"
     mask: 
     - "T{routes.mask}"
     - "C:${{value=V{mask}: vutil.isIPaddr(value)}}"


### PR DESCRIPTION
```
[root@c910f03c05k21 1.0]# cat /tmp/routes
{
    "route": {
        "gw_def": {
            "gateway": "10.3.5.21",
            "ifname": "eth0",
            "mask": "0.0.0.0",
            "net": "1.1.1.1"
        },
        "default": {
            "gateway": "10.3.5.21",
            "ifname": "eth0",
            "mask": "0.0.0.0",
            "net": "default"
        }
    },
    "schema_version": "1.0"
}
[root@c910f03c05k21 1.0]# xcat-inventory import -f /tmp/routes
Importing object: gw_def
Importing object: default
Inventory import successfully!
```