### PR TITLE
network object validation: gateway can be hostname,range can be single ip address

### DIFF
--- a/xcat-inventory/xcclient/inventory/schema/1.0/network.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/network.yaml
@@ -10,17 +10,16 @@
       mgtifname: "T{networks.mgtifname}"
       gateway: 
       - "T{networks.gateway}"
-      - "C:${{value=V{basic_attr.gateway}: True if str(value) in ('','<xcatmaster>') or vutil.isIPaddr(value) else False}}"
       mtu: "T{networks.mtu}"
       domain: "T{networks.domain}"
       vlanid: "T{networks.vlanid}"
     pool:
       dynamicrange: 
       - "T{networks.dynamicrange}"
-      - "C:${{ value=V{pool.dynamicrange}: True if str(value) in ('') or vutil.isIPrange(value) else False}}"
+      - "C:${{ value=V{pool.dynamicrange}: True if str(value) in ('') or vutil.isIPaddr(value) or vutil.isIPrange(value) else False}}"
       staticrange: 
       - "T{networks.staticrange}"
-      - "C:${{ value=V{pool.staticrange}: True if str(value) in ('') or vutil.isIPrange(value) else False}}"
+      - "C:${{ value=V{pool.staticrange}: True if str(value) in ('') or vutil.isIPrange(value) or vutil.isIPaddr(value) else False}}"
       staticrangeincrement: "T{networks.staticrangeincrement}"
       nodehostname: "T{networks.nodehostname}"
       ddnsdomain: "T{networks.ddnsdomain}"


### PR DESCRIPTION
UT:
```
[root@c910f03c05k21 1.0]# xcat-inventory export -t network  >/tmp/network
[root@c910f03c05k21 1.0]# xcat-inventory import -f /tmp/network
Importing object: hpctest3
Importing object: management
Importing object: 50_0_0_0-255_0_0_0
Importing object: 192_168_122_0-255_255_255_0
Importing object: 192_168_11_0-255_255_255_0
Inventory import successfully!
```