### PR TITLE
remove duplicate table entries in node template; refine code logic to remove table entries while importing

### DIFF
--- a/xcat-inventory/xcclient/inventory/dbfactory.py
+++ b/xcat-inventory/xcclient/inventory/dbfactory.py
@@ -27,14 +27,17 @@ def create_or_update(session,tabcls,key,newdict,ismatrixtable=True):
 
         if  tabkey != item and newdict[item] is None:
             newdict[item]=''
-    
-        if tabkey not in newdict.keys() or tabkey in newdict.keys() and (newdict[tabkey] is not None and str(newdict[tabkey]) !=""):
+        
+        #delete table rows when (1)the key is None or blank (2)the key is not specified in newdict and all non-key values are blank 
+        if tabkey not in newdict.keys(): 
             if tabkey != item and newdict[item]!='': 
                 delrow=0
+        elif newdict[tabkey] is not None and str(newdict[tabkey]) !="":
+            delrow=0
 
         if item == 'disable' and newdict[item]=='':
             newdict[item]=None
-
+   
     if not ismatrixtable:
         if skiprow:
             return

--- a/xcat-inventory/xcclient/inventory/dbfactory.py
+++ b/xcat-inventory/xcclient/inventory/dbfactory.py
@@ -28,13 +28,12 @@ def create_or_update(session,tabcls,key,newdict,ismatrixtable=True):
         if  tabkey != item and newdict[item] is None:
             newdict[item]=''
     
-        if tabkey != item and newdict[item]!='':
-            delrow=0
+        if tabkey not in newdict.keys() or tabkey in newdict.keys() and (newdict[tabkey] is not None and str(newdict[tabkey]) !=""):
+            if tabkey != item and newdict[item]!='': 
+                delrow=0
 
         if item == 'disable' and newdict[item]=='':
             newdict[item]=None
-        
-
 
     if not ismatrixtable:
         if skiprow:

--- a/xcat-inventory/xcclient/inventory/schema/1.0/node.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/node.yaml
@@ -255,7 +255,6 @@
       mpaurlpath: "T{mpa.urlpath}"
       nodehmcmdmapping: "T{nodehm.cmdmapping}"
       nodehmgetmac: "T{nodehm.getmac}"
-      nodehmpower: "T{nodehm.power}"
       nodelisthidden: "T{nodelist.hidden}"
       noderesnfsdir: "T{noderes.nfsdir}"
       noderesnimserver: "T{noderes.nimserver}"


### PR DESCRIPTION
UT:
```
[root@boston02 inventory]# cat /tmp/faketest
{
    "node": {
        "faketest": {
            "device_info": {
                "arch": "armv7l",
                "characteristics": "switch"
            },
            "device_type": "switch",
            "engines": {
                "hardware_mgt_engine": {
                    "engine_type": "switch"
                }
            },
            "network_info": {
                "otherinterfaces": "172.21.208.3",
                "primarynic": {
                    "ip": "172.21.208.13",
                    "mac": [
                        "8c:ea:1b:e8:78:c0"
                    ],
                    "switch": "mid08",
                    "switchport": "3"
                }
            },
            "obj_type": "node",
            "obj_info": {
                "groups": "all",
            },
            "role": "service"
        }
    },
    "schema_version": "1.0"
}
[root@boston02 inventory]# xcat-inventory import -f  /tmp/faketest
Importing object: faketest
Inventory import successfully!
[root@boston02 inventory]# xcat-inventory export -t node -o faketest
{
    "node": {
        "faketest": {
            "device_info": {
                "arch": "armv7l",
                "characteristics": "switch"
            },
            "device_type": "switch",
            "engines": {
                "hardware_mgt_engine": {
                    "engine_type": "switch"
                }
            },
            "network_info": {
                "otherinterfaces": "172.21.208.3",
                "primarynic": {
                    "ip": "172.21.208.13",
                    "mac": [
                        "8c:ea:1b:e8:78:c0"
                    ],
                    "switch": "mid08",
                    "switchport": "3"
                }
            },
            "obj_info": {
                "groups": "all"
            },
            "obj_type": "node",
            "role": "service"
        }
    },
    "schema_version": "1.0"
}

[root@boston02 inventory]# cat /tmp/faketest
{
    "node": {
        "faketest": {
            "device_info": {
                "arch": "armv7l",
                "characteristics": "switch"
            },
            "device_type": "server",
            "engines": {
                "hardware_mgt_engine": {
                    "engine_type": "switch"
                }
            },
            "network_info": {
                "otherinterfaces": "172.21.208.3",
                "primarynic": {
                    "ip": "172.21.208.13",
                    "mac": [
                        "8c:ea:1b:e8:78:c0"
                    ],
                    "switch": "mid08",
                    "switchport": "3"
                }
            },
            "obj_type": "group",
            "obj_info": {
                "groups": "all",
            },
            "role": "compute"
        }
    },
    "schema_version": "1.0"
}

[root@boston02 inventory]# xcat-inventory import -f  /tmp/faketest
Importing object: faketest
Inventory import successfully!
[root@boston02 inventory]# xcat-inventory export -t node -o faketest
{
    "node": {
        "faketest": {
            "device_info": {
                "arch": "armv7l",
                "characteristics": "switch"
            },
            "device_type": "server",
            "engines": {
                "hardware_mgt_engine": {
                    "engine_type": "switch"
                }
            },
            "network_info": {
                "otherinterfaces": "172.21.208.3",
                "primarynic": {
                    "ip": "172.21.208.13",
                    "mac": [
                        "8c:ea:1b:e8:78:c0"
                    ],
                    "switch": "mid08",
                    "switchport": "3"
                }
            },
            "obj_type": "group",
            "role": "compute"
        }
    },
    "schema_version": "1.0"
}

```