### PR TITLE
correct ip address validation, take ip address with leading zero as legal

### DIFF
--- a/xcat-inventory/xcclient/inventory/vutil.py
+++ b/xcat-inventory/xcclient/inventory/vutil.py
@@ -13,7 +13,7 @@ import sys
 import re
 
 def isIPaddr(varin):
-    ValidIpAddressRegex = "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"; 
+    ValidIpAddressRegex = "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.(([0-9]|[0-9]{2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){2}([0-9]|[0-9]{2}|0[0-9]{2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])$";
     return (re.match(ValidIpAddressRegex,str(varin)) is not None)
 
 def isMac(varin):


### PR DESCRIPTION
UT:
```
[root@boston02 inventory]# cat /tmp/cluster|grep '172.21.208.03'
                    "ip": "172.21.208.03",
[root@boston02 inventory]# xcat-inventory import -f  /tmp/cluster
...
Inventory import successfully!
[root@boston02 inventory]# xcat-inventory export -t node -o mid08tor03
{
    "node": {
        "mid08tor03": {
            "device_info": {
                "arch": "armv7l",
                "characteristics": "switch",
                "switchtype": "onie"
            },
            "device_type": "switch",
            "engines": {
                "hardware_mgt_engine": {
                    "engine_type": "switch"
                }
            },
            "network_info": {
                "otherinterfaces": "172.21.208.3",
                "primarynic": {
                    "ip": "172.21.208.03",
                    "mac": [
                        "8c:ea:1b:e8:78:c0"
                    ],
                    "switch": "mid08",
                    "switchport": "3"
                }
            },
            "obj_info": {
                "description": "Cumulus Linux 3.5.2 (Linux Kernel 4.1.33-1+cl3u11)",
                "groups": "switch,edge_switch"
            },
            "obj_type": "node",
            "role": "compute"
        }
    },
    "schema_version": "1.0"
}
[root@boston02 inventory]
```