### PR TITLE
enhance xcat-inventory deb pkg

### DIFF
--- a/xcat-inventory/debian/install
+++ b/xcat-inventory/debian/install
@@ -1,3 +1,3 @@
 cli/* opt/xcat/bin/
-xcclient/* /opt/xcat/lib/python/xcclient
-templates/* /opt/xcat/share/xcat/inventory_templates
+xcclient/* opt/xcat/lib/python/xcclient
+templates/* opt/xcat/share/xcat/inventory_templates

--- a/xcat-inventory/debian/install
+++ b/xcat-inventory/debian/install
@@ -1,6 +1,3 @@
 cli/* opt/xcat/bin/
-xcclient/*.py /opt/xcat/lib/python/xcclient
-xcclient/inventory/*.py /opt/xcat/lib/python/xcclient/inventory
-xcclient/inventory/schema/latest/*.yaml /opt/xcat/lib/python/xcclient/inventory/schema/latest
-xcclient/inventory/schema/1.0/*.yaml /opt/xcat/lib/python/xcclient/inventory/schema/1.0
+xcclient/* /opt/xcat/lib/python/xcclient
 templates/* /opt/xcat/share/xcat/inventory_templates


### PR DESCRIPTION
UT:
1, build deb package: ./build-ubuntu -c xcat-inventory
2, check deb package:
```
dpkg-deb -c xcat-inventory_0.1.1-snap201804032323_all.deb
```
3, install and run `xcat-inventory export`, print correct result.