### PR TITLE
Offer another automatic versioning convention based on GitHub tags and commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Version

--- a/makepythonrpm
+++ b/makepythonrpm
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
+# IBM(c) 2018 EPL license http://www.eclipse.org/legal/epl-v10.html
 
 # Common script to make any one the xcat rpms.  To build locally, run in the top dir of local svn repository, for example:
 #   ./makepythonrpm xcat-inventory
@@ -8,15 +8,14 @@
 function makepythoncli {
     RPMNAME="$1"
     SPEC_FILE="xcat-inventory.spec"
-    sed -i s/%%REPLACE_CURRENT_VERSION%%/${VER}/g $RPMNAME/${SPEC_FILE}
-    VERINFO=${VER}' (git commit '${GITCOMMIT}')'
-    sed -i s/\#VERSION_SUBSTITUTE\#/"$VERINFO"/g $RPMNAME/xcclient/inventory/shell.py
-    tar --exclude .svn -czvf $RPMROOT/SOURCES/$RPMNAME-${VER}.tar.gz $RPMNAME
-    rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VER*rpm
-    echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$VER-snap*.noarch.rpm $EMBEDTXT..."
-    rpmbuild --quiet -ta $RPMROOT/SOURCES/$RPMNAME-${VER}.tar.gz --define "version $VER" $REL "$EASE"
+    sed -i s/%%REPLACE_CURRENT_VERSION%%/${VERSION}/g $RPMNAME/${SPEC_FILE}
+    VERINFO=${VERSION}' (git commit '${GITCOMMIT}')'
+    tar --exclude .svn -czvf $RPMROOT/SOURCES/$RPMNAME-${VERSION}.tar.gz $RPMNAME
+    rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VERSION*rpm
+    echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$VERSION*.noarch.rpm $EMBEDTXT..."
+    rpmbuild --quiet -ta $RPMROOT/SOURCES/$RPMNAME-${VERSION}.tar.gz --define "version $VERSION" --define "release c$NUMCOMMITS" --define "gitcommit $GITCOMMIT"
     if [ $? -eq 0 ]; then
-        ls $RPMROOT/RPMS/noarch/$RPMNAME-$VER-snap*.noarch.rpm
+        ls $RPMROOT/RPMS/noarch/$RPMNAME-$VERSION*.noarch.rpm
         exit 0
     else  
         exit 1
@@ -30,12 +29,16 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
+VERSION=`git describe --tags|cut -d- -f 1`
+NUMCOMMITS=`git describe --tags|cut -d- -f 2`
+if [ "$NUMCOMMITS" != "$VERSION"  ]; then
+    VERSION=$VERSION
+fi
+echo $VERSION > Version
+
 OSNAME=$(uname)
-VER=`cat Version`
 GITCOMMIT=$(git rev-parse HEAD)
-REL="--define"
-EASE='usedate 1'
-RPMROOT=/root/rpmbuild
+RPMROOT=~/rpmbuild
 
 rpmbuild --version > /dev/null
 if [ $? -gt 0 ]; then

--- a/xcat-inventory/xcat-inventory.spec
+++ b/xcat-inventory/xcat-inventory.spec
@@ -23,6 +23,8 @@ BuildArch: noarch
 %setup -q -n xcat-inventory
 
 %build
+VERINFO=%{version}' (git commit '%{gitcommit}')'
+sed -i s/\#VERSION_SUBSTITUTE\#/"$VERINFO"/g $RPM_BUILD_DIR/$RPM_PACKAGE_NAME/xcclient/inventory/shell.py
 
 %install
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Resolves #20 and #21 

Here the version is based on a tag and git calls , check out the changes in  `makepythonrpm` .  I dislike how xCAT is using the `snap.....` convention and if we are creating new RPMs, we should use a better version system. 

* Since this change will write to Version file, i added that to .gitignore. 
* Modify the shell.py file in the BUILD directory of rpm, so not modifying source


Running: 
```
[vhu@c910loginx01 xcat-inventory]$ ./makepythonrpm xcat-inventory | grep rpm
xcat-inventory/deps/python-PyMySQL-0.7.6-6.2.noarch.rpm
Building /u/vhu/rpmbuild/RPMS/noarch/xcat-inventory-v0.1.2*.noarch.rpm ...
/u/vhu/rpmbuild/RPMS/noarch/xcat-inventory-v0.1.2-c1.noarch.rpm
```

now commit another....
```
[vhu@c910loginx01 xcat-inventory]$ git add makepythonrpm
[vhu@c910loginx01 xcat-inventory]$ git commit -m "Offer another automatic versioning convention based on GitHub tags and number of commits"
[build_changes 39eac94] Offer another automatic versioning convention based on GitHub tags and number of commits
 3 files changed, 19 insertions(+), 13 deletions(-)
 create mode 100644 .gitignore
[vhu@c910loginx01 xcat-inventory]$ ./makepythonrpm xcat-inventory | grep rpm
xcat-inventory/deps/python-PyMySQL-0.7.6-6.2.noarch.rpm
Building /u/vhu/rpmbuild/RPMS/noarch/xcat-inventory-v0.1.2*.noarch.rpm ...
/u/vhu/rpmbuild/RPMS/noarch/xcat-inventory-v0.1.2-c2.noarch.rpm
```

So the versioning is based on git...  
