### PR TITLE
Fix the issue to print help message

### DIFF
--- a/xcat-inventory/xcclient/shell.py
+++ b/xcat-inventory/xcclient/shell.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ###############################################################################
-# IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
+# IBM(c) 2018 EPL license http://www.eclipse.org/legal/epl-v10.html
 ###############################################################################
 # -*- coding: utf-8 -*-
 #
@@ -47,7 +47,7 @@ class ClusterShell(object):
         parser.add_argument('-h',
                             '--help',
                             action='store_true',
-                            help=argparse.SUPPRESS)
+                            help="Prints help message")
 
         parser.add_argument('--debug',
                             default=False,
@@ -166,9 +166,17 @@ class ClusterShell(object):
 
         # Handle top-level --help/-h before attempting to parse
         # a command off the command line
-        if not argv or options.help:
+        if not argv:
             self.do_help(options)
             return 0
+
+        if not args:
+            self.do_help(options)
+            return 0
+
+        if args[0] not in self.subcommands.keys():
+            self.do_help(options)
+            raise inventory.exceptions.CommandException("Error: not a valid subcommand to run")
 
         # Parse args again and call whatever callback was selected
         args = subcommand_parser.parse_args(argv)


### PR DESCRIPTION
To fix https://github.com/xcat2/xcat-inventory/issues/19

UT:
```
# xcat-inventory -h
usage: xcat-inventory [-h] [--debug] [-v] [-V] <subcommand> ...

xCAT inventory management tool

Positional arguments:
  <subcommand>
    export       Export the inventory data from xcat database
    help         Display help about this program or one of its subcommands.
    import       Import inventory file to xcat database

Optional arguments:
  -h, --help     Prints help message
  --debug        Prints debugging output into the log file (not implemented
                 yet).
  -v, --verbose  Prints verbose output (not implemented yet).
  -V, --version  Shows the program version and exits.

See "xcat-inventory help COMMAND" for help on a specific command.

# xcat-inventory export -h
usage: xcat-inventory export [-t <type>] [-o <name>] [-f <path>]
                             [-s <version>] [--format <format>]

Export the inventory data from xcat database

Arguments:
  -t <type>, --type <type>
                        type of objects to export, valid values:
                        node,passwd,osimage,network,zone,policy,route,site. If
                        not specified, all objects in xcat databse will be
                        exported
  -o <name>, --objects <name>
                        names of the objects to export, delimited with
                        Comma(,). If not specified, all objects of the
                        specified type will be exported
  -f <path>, --path <path>
                        path of the inventory file(not implemented yet)
  -s <version>, --schema-version <version>
                        schema version of the inventory data. Valid values:
                        1.0,latest. If not specified, the "latest" schema
                        version will be used
  --format <format>     format of the inventory data, valid values: json,
                        yaml. json will be used by default if not specified
[root@stratton01 xcclient]# xcat-inventory export -t -h
usage: xcat-inventory export [-t <type>] [-o <name>] [-f <path>]
                             [-s <version>] [--format <format>]
xcat-inventory export: error: argument -t/--type: expected one argument

# xcat-inventory export -t abc -h
usage: xcat-inventory export [-t <type>] [-o <name>] [-f <path>]
                             [-s <version>] [--format <format>]

Export the inventory data from xcat database

Arguments:
  -t <type>, --type <type>
                        type of objects to export, valid values:
                        node,passwd,osimage,network,zone,policy,route,site. If
                        not specified, all objects in xcat databse will be
                        exported
  -o <name>, --objects <name>
                        names of the objects to export, delimited with
                        Comma(,). If not specified, all objects of the
                        specified type will be exported
  -f <path>, --path <path>
                        path of the inventory file(not implemented yet)
  -s <version>, --schema-version <version>
                        schema version of the inventory data. Valid values:
                        1.0,latest. If not specified, the "latest" schema
                        version will be used
  --format <format>     format of the inventory data, valid values: json,
                        yaml. json will be used by default if not specified
```