### PR TITLE
Separate out source control for osimage #18

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -134,8 +134,6 @@ def validate_args(args, action):
            raise CommandException("Error: Invalid file to import: \"%(p)s\"", p=args.path)
         if not os.path.exists(args.path):
             raise CommandException("Error: The specified path does not exist: %(p)s", p=args.path)
-        if not args.exclude:
-            raise CommandException("Error: -x|--exclude is not supported.")
 
     if action == 'export': #extra validation for export
         if args.format and args.format.lower() not in VALID_OBJ_FORMAT:

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -47,6 +47,7 @@ class InventoryShell(shell.ClusterShell):
             mgr.import_all(args.path, dryrun=args.dryrun,version=args.version,update=args.update)
 
     @shell.arg('-t','--type', metavar='<type>', help='type of objects to export, valid values: '+','.join(mgr.InventoryFactory.getvalidobjtypes())+'. '+'If not specified, all objects in xcat databse will be exported')
+    @shell.arg('-x', '--exclude', dest='exclude', default='', help='types to be excluded when exporting all, delimited with Comma(,).')
     @shell.arg('-o','--objects', dest='name',metavar='<name>', help='names of the objects to export, delimited with Comma(,). If not specified, all objects of the specified type will be exported')
     @shell.arg('-f','--path', metavar='<path>', help='path of the inventory file(not implemented yet)')
     @shell.arg('-s','--schema-version', dest='version',metavar='<version>', help='schema version of the inventory data. Valid values: '+','.join(mgr.InventoryFactory.getAvailableSchemaVersions())+'. '+'If not specified, the "latest" schema version will be used')
@@ -56,9 +57,9 @@ class InventoryShell(shell.ClusterShell):
         mgr.validate_args(args, 'export')
         if args.type :
             # do export by type
-            mgr.export_by_type(args.type, args.name, args.path, args.format,version=args.version)
+            mgr.export_by_type(args.type, args.name, args.path, args.format, version=args.version)
         else :
-            mgr.export_all(args.path, args.format,version=args.version)
+            mgr.export_all(args.path, args.format, exclude=args.exclude.split(','), version=args.version)
 
 # main entry for CLI
 def main():


### PR DESCRIPTION
To address #18 
Introduce `-x|--exclude` to exclude some types when export all.

UT:
```
xcat-inventory help export
usage: xcat-inventory export [-t <type>] [-x EXCLUDE] [-o <name>] [-f <path>]
                             [-s <version>] [--format <format>]

Export the inventory data from xcat database

Arguments:
  -t <type>, --type <type>
                        type of objects to export, valid values:
                        node,network,passwd,route,site,osimage,policy. If not
                        specified, all objects in xcat databse will be
                        exported
  -x EXCLUDE, --exclude EXCLUDE
                        types to be excluded when exporting all, delimited
                        with Comma(,).
  -o <name>, --objects <name>
                        names of the objects to export, delimited with
                        Comma(,). If not specified, all objects of the
                        specified type will be exported
  -f <path>, --path <path>
                        path of the inventory file(not implemented yet)
  -s <version>, --schema-version <version>
                        schema version of the inventory data. Valid values:
                        1.0,latest. If not specified, the "latest" schema
                        version will be used
  --format <format>     format of the inventory data, valid values: json,
                        yaml. json will be used by default if not specified
```

```
xcat-inventory export --exclude foo
Error: Invalid object type to exclude: "foo"
```

```
xcat-inventory export --exclude osimage,node
```
And in the output, there is no `osimage` and `node` type objects.