### PR TITLE
enhance xcat-inventory export/import for osimage

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -73,7 +73,6 @@ class InventoryFactory(object):
         return InventoryFactory.__db__
 
     def exportObjs(self, objlist, location=None,fmt='json'):
-        #print("location="+location)
         myclass = InventoryFactory.__InventoryClass__[self.objtype]
         myclass.loadschema(self.schemapath)
         tabs=myclass.gettablist()
@@ -95,6 +94,10 @@ class InventoryFactory(object):
                     shutil.rmtree(mydir)
                 os.mkdir(mydir) 
                 myfile=mydir+'/'+'definition.yaml'
+                if fmt=='yaml':
+                    myfile=mydir+'/'+'definition.yaml'
+                elif fmt=='json':
+                    myfile=mydir+'/'+'definition.json'
                 dumpobj(myobjdict2dump,fmt,myfile) 
                 for imgfile in osimagefiles:
                     if os.path.exists(imgfile):
@@ -107,7 +110,7 @@ class InventoryFactory(object):
                             pass
                         shutil.copyfile(imgfile,dstfile)
                     else:
-                        print("The file \""+imgfile+"\" of osimage object \""+key+"\" does not exist",file=sys.stderr) 
+                        print("The file \""+imgfile+"\" of "+self.objtype+" object \""+key+"\" does not exist",file=sys.stderr) 
         return objdict
         
     @classmethod
@@ -124,15 +127,17 @@ class InventoryFactory(object):
         myclass = InventoryFactory.__InventoryClass__[self.objtype]
         myclass.loadschema(self.schemapath)
         dbdict = {}
+        objfiles={}
         for key, attrs in obj_attr_dict.items():
             if not objlist or key in objlist:
                 newobj = myclass.createfromfile(key, attrs)
-                print(newobj.getfilestosave())
+                objfiles[key]=newobj.getfilestosave()
                 dbdict.update(newobj.getdbdata())
         tabs=myclass.gettablist()
         if not update:
             self.getDBInst().cleartab(tabs)
         self.getDBInst().settab(dbdict)
+        return objfiles
 
 
 def dumpobj(objdict, fmt='json',location=None):
@@ -160,14 +165,19 @@ def dump2json(xcatobj, location=None):
     #TODO: store in file or directory
 
 def validate_args(args, action):
-    if args.type is not None and args.type.lower() not in InventoryFactory.getvalidobjtypes():
-        raise CommandException("Error: Invalid object type: \"%(t)s\"", t=args.type)
+    if args.type is not None:
+        objtypelist=[]
+        objtypelist.extend(args.type.split(','))
+        invalidobjtypes=list(set(objtypelist).difference(set(InventoryFactory.getvalidobjtypes())))
+        if invalidobjtypes:
+            raise CommandException("Error: Invalid object type: \"%(t)s\"", t=','.join(invalidobjtypes))
+        if len(objtypelist)!=1 and args.name:
+            raise CommandException("Error: object names cannot be specified with multiple object types!")
     if args.name == '':
-        raise CommandException("Error: Invalid objects name: \"%(o)s\"", o=args.name)
+        raise CommandException("Error: Invalid object names: \"%(o)s\"", o=args.name)
     if args.name and not args.type:
         raise CommandException("Error: Missing object type for object: %(o)s", o=args.name)
-    if args.path and (not args.type or args.type !='osimage'):
-        raise CommandException("Error: -f|--path is only valid for -t|--type=osimage")
+
     
     if action == 'import': #extra validation for export
         if not args.path:
@@ -176,6 +186,8 @@ def validate_args(args, action):
             raise CommandException("Error: The specified path does not exist: %(p)s", p=args.path)
 
     if action == 'export': #extra validation for export
+        #if args.path and (not args.type or args.type !='osimage'):
+        #    raise CommandException("Error: -f|--path is only valid for -t|--type=osimage")
         if args.format and args.format.lower() not in VALID_OBJ_FORMAT:
             raise CommandException("Error: Invalid exporting format: %(f)s", f=args.format)
         if args.exclude:
@@ -183,60 +195,82 @@ def validate_args(args, action):
                 if et.lower() not in InventoryFactory.getvalidobjtypes():
                     raise CommandException("Error: Invalid object type to exclude: \"%(t)s\"", t=et)
 
-def export_by_type(objtype, names, location=None, fmt='json',version=None):
-    if location and not os.path.exists(location):
-        raise CommandException("Error: non-exist path %(f)s",f=location)
+def export_by_type(objtype, names, location=None, fmt='json',version=None,exclude=None):
+    if location:
+        if not objtype and not os.path.isdir(location):
+            raise CommandException("Error: non-exist directory %(f)s",f=location)
+        elif objtype and objtype!='osimage' and os.path.exists(location) and not os.path.isfile(location):
+            raise CommandException("Error: the specified path %(f)s already exists and is not a file!", f=location)
     
+    if objtype and objtype != 'osimage' and location and os.path.isdir(location):
+        raise CommandException("Error: directory %(f)s specified by -f|--path is only supported when [-t|--type osimage] or export all without [-t|--type] specified",f=location)
+
     InventoryFactory.getLatestSchemaVersion()
     dbsession=DBsession()
-    hdl = InventoryFactory.createHandler(objtype,dbsession,version)
+
     objlist = []
-    if names:
-        objlist.extend(names.split(','))
-
-    typedict=hdl.exportObjs(objlist, location,fmt)
-    nonexistobjlist=list(set(objlist).difference(set(typedict[objtype].keys())))
-    if nonexistobjlist:
-        raise ObjNonExistException("Error: cannot find objects: %(f)s!", f=','.join(nonexistobjlist))
-   
-    if version is None or version in ('latest'):
-        version=InventoryFactory.getLatestSchemaVersion()
-    typedict['schema_version']=version    
-   
-    if not location: 
-        if not fmt or fmt.lower() == 'json':
-            dump2json(typedict)
-        else:
-            dump2yaml(typedict)
-    dbsession.close() 
-
-
-def export_all(location, fmt, exclude=None, version=None):
-    dbsession=DBsession()
-    wholedict={}
-    for objtype in InventoryFactory.getvalidobjtypes():
-        if exclude and objtype in exclude:
-            continue
-        hdl = InventoryFactory.createHandler(objtype,dbsession,version)
-        wholedict.update(hdl.exportObjs([]))
-
-    if version is None or version in ('latest'):
-        version=InventoryFactory.getLatestSchemaVersion()
-    wholedict['schema_version']=version
-
-    if not fmt or fmt.lower() == 'json':
-        dump2json(wholedict)
+    objtypelist=[]
+    exportall=0
+    if objtype:
+        objtypelist.extend(objtype.split(','))
     else:
-        dump2yaml(wholedict)
-    dbsession.close() 
+        objtypelist.extend(InventoryFactory.getvalidobjtypes())
+        exportall=1
+        
 
-def import_by_type(objtype, names, location,dryrun=None,version=None,update=True):
-    dbsession=DBsession()
-
-    objlist = []
     if names:
         objlist.extend(names.split(','))
-    
+    wholedict={} 
+
+    for myobjtype in objtypelist:
+        if exclude and myobjtype in exclude:
+            continue
+        hdl = InventoryFactory.createHandler(myobjtype,dbsession,version)
+        if myobjtype == 'osimage' and location and os.path.isdir(location):
+            if exportall:
+                mylocation=location+'/'+myobjtype
+                if not os.path.exists(mylocation):
+                    os.mkdir(mylocation)
+            else:
+                mylocation=location
+        else:
+            mylocation=None
+        
+        typedict=hdl.exportObjs(objlist,mylocation,fmt)
+        nonexistobjlist=list(set(objlist).difference(set(typedict[myobjtype].keys())))
+        if nonexistobjlist:
+            raise ObjNonExistException("Error: cannot find "+myobjtype+" objects: %(f)s!", f=','.join(nonexistobjlist))
+        if not location or os.path.isfile(location) or myobjtype!='osimage' :
+            wholedict.update(typedict)
+      
+    if version is None or version in ('latest'):
+        version=InventoryFactory.getLatestSchemaVersion()
+    wholedict['schema_version']=version    
+   
+    if 'osimage' in objtypelist and exportall!=1 and location and os.path.isdir(location):
+        objtypelist.remove('osimage')
+
+    if objtypelist:
+        if location:
+            if exportall==1 and os.path.isdir(location):
+                if not fmt or fmt.lower() == 'json':
+                    mylocation=location+'/cluster.json'
+                else:
+                    mylocation=location+'/cluster.yaml'
+                dumpobj(wholedict, fmt,mylocation)
+            else:
+                dumpobj(wholedict, fmt,location)
+        else: 
+            if not fmt or fmt.lower() == 'json':
+                dump2json(wholedict)
+            else:
+                dump2yaml(wholedict)
+    dbsession.close() 
+
+
+
+def importfromfile(objtypelist, objlist, location,dryrun=None,version=None,update=True):
+    dbsession=DBsession()
     with open(location) as file:
         contents=file.read()
     try:
@@ -258,20 +292,28 @@ def import_by_type(objtype, names, location,dryrun=None,version=None,update=True
     if version and version != versinfile:
         raise CommandException("Error: the specified schema version \""+version+"\" does not match the schema_version \""+versinfile+"\" in input file "+location ) 
     version=versinfile
-
-    hdl = InventoryFactory.createHandler(objtype,dbsession,version)
-
-    if objtype: 
-        if objtype not in obj_attr_dict.keys():
-            raise ObjNonExistException("Error: cannot find object type '"+objtype+"' in the file "+location)
-        else:
-            nonexistobjlist=list(set(objlist).difference(set(obj_attr_dict[objtype].keys())))
+   
+    InventoryFactory.validateObjLayout(obj_attr_dict) 
+    objfiledict={}
+    if objtypelist: 
+        nonexistobjtypelist=list(set(objtypelist).difference(set(obj_attr_dict.keys())))
+        if nonexistobjtypelist:
+            raise ObjNonExistException("Error: cannot find object types: %(f)s in the file "+location+'!', f=','.join(nonexistobjtypelist))
+        for myobjtype in objtypelist:
+            nonexistobjlist=list(set(objlist).difference(set(obj_attr_dict[myobjtype].keys())))
             if nonexistobjlist:
                 raise ObjNonExistException("Error: cannot find objects: %(f)s!", f=','.join(nonexistobjlist))
-            else:
-                hdl.importObjs(objlist, obj_attr_dict[objtype],update)
+            hdl = InventoryFactory.createHandler(myobjtype,dbsession,version)
+            if myobjtype not in objfiledict.keys():
+                objfiledict[myobjtype]={}
+            objfiledict[myobjtype].update(hdl.importObjs(objlist, obj_attr_dict[myobjtype],update))
     else:
-        hdl.importObjs(objlist, obj_attr_dict,update) 
+        for objtype in obj_attr_dict.keys():#VALID_OBJ_TYPES:
+            hdl = InventoryFactory.createHandler(objtype,dbsession,version)
+            if objtype not in objfiledict.keys():
+                objfiledict[objtype]={}
+            objfiledict[objtype].update(hdl.importObjs([], obj_attr_dict[objtype],update))
+
     if not dryrun:
         try:
             dbsession.commit()   
@@ -282,44 +324,99 @@ def import_by_type(objtype, names, location,dryrun=None,version=None,update=True
     else:
         print("Dry run mode, nothing will be written to database!")
     dbsession.close()
+    return objfiledict
 
-def import_all(location,dryrun=None,version=None,update=True):
-    dbsession=DBsession()
-    with open(location) as file:
-        contents=file.read()
-    try:
-        obj_attr_dict = json.loads(contents)
-    except ValueError:
-        try:
-            obj_attr_dict = yaml.load(contents)
-        except Exception,e:
-            raise InvalidFileException("Error: failed to load file "+location+": "+str(e))
 
-    versinfile=None
-    if 'schema_version' in obj_attr_dict.keys():
-        versinfile=obj_attr_dict['schema_version']
-        del obj_attr_dict['schema_version']
-    if not versinfile or versinfile == 'latest':
-        versinfile=InventoryFactory.getLatestSchemaVersion()
-    if version == 'latest':
-        version=InventoryFactory.getLatestSchemaVersion()
-    if version and version != versinfile:
-        raise CommandException("Error: the specified schema version \""+version+"\" does not match the schema_version \""+versinfile+"\" in input file "+location )
-    version=versinfile
-   
-    InventoryFactory.validateObjLayout(obj_attr_dict) 
-    for objtype in obj_attr_dict.keys():#VALID_OBJ_TYPES:
-        hdl = InventoryFactory.createHandler(objtype,dbsession,version)
-        hdl.importObjs([], obj_attr_dict[objtype],update)
-    
-    if not dryrun:
-        try:
-            dbsession.commit()
-        except Exception, e:
-            raise DBException("Error on commit DB transactions: "+str(e))
-        else:
-            print('Inventory import successfully!')
+def importobjdir(location,dryrun=None,version=None,update=True):
+    objfile=None
+    if os.path.exists(location+'/'+'definition.yaml'):
+        objfile=location+'/'+'definition.yaml'
+    elif os.path.exists(location+'/'+'definition.json'):
+        objfile=location+'/'+'definition.json'    
     else:
-        print("Dry run mode, nothing will be written to database!")
-    dbsession.close()
+        raise InvalidFileException("Error: no definition.json or definition.yaml found under \""+location+"\""+"!")
+    objfilesdict=importfromfile(None,None,objfile,dryrun,version,update)
+    if len(objfilesdict.keys()) !=1:
+        raise InvalidFileException("Error: invalid definition file: \""+objfile+"\": should contain only 1 object type")  
+    else:
+        objtype=objfilesdict.keys()[0]
+    if len(objfilesdict[objtype].keys()) !=1:
+        raise InvalidFileException("Error: invalid definition file: \""+objfile+"\": should contain only 1 object")
+    else:
+        objname=objfilesdict[objtype].keys()[0]
+    objfiles=objfilesdict[objtype][objname]
+    for myfile in objfiles:
+        srcfile=location+myfile
+        if os.path.exists(srcfile):
+            try:
+                os.makedirs(os.path.dirname(myfile))
+            except OSError, e:
+                if e.errno != os.errno.EEXIST:
+                    raise
+                pass
+            shutil.copyfile(srcfile,myfile)
+        else:
+            print("the file \""+srcfile+"\" of osimage \""+objname+"\" does not exist!",file=sys.stderr)
+
+def importfromdir(location,objtype='osimage',objnames=None,dryrun=None,version=None,update=True):
+    objnamelist=[]
+    if not objnames:
+        objnamelist=os.listdir(location)
+    else:
+        objnamelist=objnames.split(',')
+    for objname in objnamelist:
+        if os.path.exists(location+'/'+objname):
+            objdir=location+'/'+objname
+            importobjdir(objdir,dryrun,version,update)
+        else:
+            print("the specified object \""+objname+"\" does not exist under \""+location+"\"!",file=sys.stderr)
+     
+def importobj(location,objtype,objnames=None,dryrun=None,version=None,update=True):
+     objtypelist=[]
+     if objtype:
+         objtypelist=objtype.split(',')
+
+     objnamelist=[]
+     if objnames:
+         objnamelist=objnames.split(',')
+
+     if os.path.isfile(location):
+         importfromfile(objtypelist, objnamelist, location,dryrun,version,update)
+     elif os.path.isdir(location):
+         clusterfile=None
+         if os.path.exists(location+'/'+'cluster.yaml'):
+             clusterfile=location+'/'+'cluster.yaml'
+         elif os.path.exists(location+'/'+'cluster.json'):
+             clusterfile=location+'/'+'cluster.json'
+
+         #this is a cluster directory
+         if clusterfile:
+             myobjtypelist=[]
+             myobjtypelist.extend(objtypelist)
+
+             if 'osimage' in myobjtypelist:
+                 myobjtypelist.remove('osimage')
+                 if myobjtypelist:
+                     importfromfile(myobjtypelist,objnamelist,clusterfile,dryrun,version,update)
+                 importfromdir(location+'/osimage/','osimage',objnames,dryrun,version,update)
+             else:
+                 importfromfile(objtypelist,objnamelist,clusterfile,dryrun,version,update)
+         else:
+             objfile=None
+             if os.path.exists(location+'/'+'definition.yaml'):
+                 objfile=location+'/'+'definition.yaml'
+             elif os.path.exists(location+'/'+'definition.json'):
+                 objfile=location+'/'+'definition.json'
+
+             #this is a osimage derectory
+             if 'osimage' in objtypelist:
+                 if objfile:
+                     importobjdir(location,'osimage',objnames,dryrun,version,update)
+                 else:
+                     importfromdir(location,'osimage',objnames,dryrun,version,update)
+             else:
+                 raise InvalidFileException("Error: invalid directory "+location+"!")
+                 
+     else:
+         raise InvalidFileException("Error: invalid path \""+location+"\""+"!")
 

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -207,8 +207,8 @@ def validate_args(args, action):
                     raise CommandException("Error: Invalid object type to exclude: \"%(t)s\"", t=et)
 
 def export_by_type(objtype, names, destfile=None, destdir=None, fmt='json',version=None,exclude=None):
-    if objtype and objtype != 'osimage' and location and os.path.isdir(location):
-        raise CommandException("Error: directory %(f)s specified by -f|--path is only supported when [-t|--type osimage] or export all without [-t|--type] specified",f=location)
+    if objtype and objtype != 'osimage' and destdir:
+        raise CommandException("Error: directory %(f)s specified by -f|--path is only supported when [-t|--type osimage] or export all without [-t|--type] specified",f=destdir)
 
     InventoryFactory.getLatestSchemaVersion()
     dbsession=DBsession()
@@ -233,8 +233,9 @@ def export_by_type(objtype, names, destfile=None, destdir=None, fmt='json',versi
         if myobjtype == 'osimage' and destdir:
             if exportall:
                 mylocation=destdir+'/'+myobjtype
-                if not os.path.exists(mylocation):
-                    os.mkdir(mylocation)
+                if os.path.exists(mylocation):
+                    shutil.rmtree(mylocation)
+                os.mkdir(mylocation)
             else:
                 mylocation=destdir
         else:
@@ -434,7 +435,7 @@ def importobj(srcfile,srcdir,objtype,objnames=None,dryrun=None,version=None,upda
                          importobjdir(srcdir,dryrun,version,update)
                  else:
                      #this is an osimage inventory directory 
-                     importfromdir(srcdir,'osimage',objnames,dryrun,version,update)
+                     importfromdir(srcdir,'osimage',objnamelist,dryrun,version,update)
                  if 'osimage' in objtypelist:
                      objtypelist.remove('osimage')
    

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -364,7 +364,12 @@ def importobjdir(location,dryrun=None,version=None,update=True):
                 if e.errno != os.errno.EEXIST:
                     raise
                 pass
-            shutil.copyfile(srcfile,myfile)
+            if os.path.exists(myfile):
+                print("Warning: the "+myfile+" already exists, will be overwritten", file=sys.stderr)
+            if os.path.samefile(srcfile,myfile):
+                print("Warning: \"%s\" and \"%s\" are the same file, skip copy"%(srcfile,myfile),file=sys.stderr)
+            else:
+                shutil.copyfile(srcfile,myfile)
         else:
             print("Warning: the file \""+srcfile+"\" of osimage \""+objname+"\" does not exist!",file=sys.stderr)
     print("The object "+objname+" has been imported")

--- a/xcat-inventory/xcclient/inventory/schema/1.0/node.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/node.yaml
@@ -23,7 +23,7 @@
     device_info:
       arch: 
       - "T{nodetype.arch}"
-      - "C:${{arch=V{device_info.arch}: False if arch and str(arch) not in ('ppc64','ppc64el','ppc64le','x86_64','armv7l') else True}}"
+      - "C:${{arch=V{device_info.arch}: False if arch and str(arch) not in ('ppc64','ppc64el','ppc64le','x86_64','armv7l','armel') else True}}"
       supportedarchs: 
       - "T{nodetype.supportedarchs}"
       disksize: "T{hwinv.disksize}"

--- a/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
@@ -19,9 +19,13 @@
     - "T{osimage.provmethod}"
     - "C:${{value=V{provision_mode}: True if str(value) in ('install','netboot','statelite') else False}}"
     package_selection:
-      pkglist: "T{linuximage.pkglist}"
+      pkglist: 
+      - "T{linuximage.pkglist}"
+      - "F:${{flist=V{package_selection.pkglist}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
       pkgdir: "T{linuximage.pkgdir}"
-      otherpkglist: "T{linuximage.otherpkglist}"
+      otherpkglist: 
+      - "T{linuximage.otherpkglist}"
+      - "F:${{flist=V{package_selection.otherpkglist}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/immarvin/')] }}"
       otherpkgdir: "T{linuximage.otherpkgdir}"
     osupdatename: "T{osimage.osupdatename}"
     kernel_driver:
@@ -35,14 +39,25 @@
     kernel_dump:
       dump: "T{linuximage.dump}"
       crashkernelsize: "T{linuximage.crashkernelsize}"
-    template: "${{imagetype=V{imagetype} :T{winimage.template} if imagetype == 'windows' else T{linuximage.template} if imagetype == 'linux' else None }} "
-    diskpartitionspec: "${{imagetype=V{imagetype} :T{linuximage.partitionfile} if imagetype == 'linux' else T{winimage.partitionfile} if imagetype == 'windows' else None}}"
-    filestosync: "T{osimage.synclists}"
+    template: 
+    - "${{imagetype=V{imagetype} :T{winimage.template} if imagetype == 'windows' else T{linuximage.template} if imagetype == 'linux' else None }} "
+    - "F:${{flist=V{template}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/immarvin') ] }}"
+      
+    diskpartitionspec: 
+    - "${{imagetype=V{imagetype} :T{linuximage.partitionfile} if imagetype == 'linux' else T{winimage.partitionfile} if imagetype == 'windows' else None}}"
+    - "F:${{flist=V{diskpartitionspec}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/immarvin') ] }}"
+    filestosync: 
+    - "T{osimage.synclists}"
+    - "F:${{flist=V{filestosync}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/immarvin') ] }}"
     addkcmdline: "T{linuximage.addkcmdline}"
     boottarget: "T{linuximage.boottarget}"                                 
     genimgoptions:
-      exlist: "T{linuximage.exlist}"
-      postinstall: "T{linuximage.postinstall}"
+      exlist: 
+      - "T{linuximage.exlist}"
+      - "F:${{flist=V{genimgoptions.exlist}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/immarvin/')] }}"
+      postinstall: 
+      - "T{linuximage.postinstall}"
+      - "F:${{flist=V{genimgoptions.postinstall}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/immarvin/')] }}"
       rootimgdir: "T{linuximage.rootimgdir}"
       nodebootif: "T{linuximage.nodebootif}"
       permission: "T{linuximage.permission}"

--- a/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
@@ -14,7 +14,7 @@
       groups: "T{osimage.groups}"
     role: 
     - "T{osimage.profile}"
-    - "C:${{value=V{role}: True if str(value) in ('compute','service') else False}}"
+    - "C:${{value=V{role}: True if str(value) in ('','compute','service') else False}}"
     provision_mode: 
     - "T{osimage.provmethod}"
     - "C:${{value=V{provision_mode}: True if str(value) in ('install','netboot','statelite') else False}}"
@@ -25,7 +25,7 @@
       pkgdir: "T{linuximage.pkgdir}"
       otherpkglist: 
       - "T{linuximage.otherpkglist}"
-      - "F:${{flist=V{package_selection.otherpkglist}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/immarvin/')] }}"
+      - "F:${{flist=V{package_selection.otherpkglist}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       otherpkgdir: "T{linuximage.otherpkgdir}"
     osupdatename: "T{osimage.osupdatename}"
     kernel_driver:
@@ -41,23 +41,23 @@
       crashkernelsize: "T{linuximage.crashkernelsize}"
     template: 
     - "${{imagetype=V{imagetype} :T{winimage.template} if imagetype == 'windows' else T{linuximage.template} if imagetype == 'linux' else None }} "
-    - "F:${{flist=V{template}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/immarvin') ] }}"
+    - "F:${{flist=V{template}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
       
     diskpartitionspec: 
     - "${{imagetype=V{imagetype} :T{linuximage.partitionfile} if imagetype == 'linux' else T{winimage.partitionfile} if imagetype == 'windows' else None}}"
-    - "F:${{flist=V{diskpartitionspec}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/immarvin') ] }}"
+    - "F:${{flist=V{diskpartitionspec}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
     filestosync: 
     - "T{osimage.synclists}"
-    - "F:${{flist=V{filestosync}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/immarvin') ] }}"
+    - "F:${{flist=V{filestosync}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
     addkcmdline: "T{linuximage.addkcmdline}"
     boottarget: "T{linuximage.boottarget}"                                 
     genimgoptions:
       exlist: 
       - "T{linuximage.exlist}"
-      - "F:${{flist=V{genimgoptions.exlist}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/immarvin/')] }}"
+      - "F:${{flist=V{genimgoptions.exlist}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       postinstall: 
       - "T{linuximage.postinstall}"
-      - "F:${{flist=V{genimgoptions.postinstall}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/immarvin/')] }}"
+      - "F:${{flist=V{genimgoptions.postinstall}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       rootimgdir: "T{linuximage.rootimgdir}"
       nodebootif: "T{linuximage.nodebootif}"
       permission: "T{linuximage.permission}"

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -54,7 +54,7 @@ class InventoryShell(shell.ClusterShell):
     def do_export(self, args):
         """Export the inventory data from xcat database"""
         mgr.validate_args(args, 'export')
-        mgr.export_by_type(args.type, args.name, args.path,args.directory,args.format, version=args.version,exclude=args.exclude.split(','))
+        mgr.export_by_type(args.type, args.name, args.path, args.directory, args.format, version=args.version, exclude=args.exclude.split(','))
 
 # main entry for CLI
 def main():

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -15,6 +15,7 @@ from exceptions import *
 import re
 import sys
 import traceback
+import os
 
 try: 
     import xcclient.inventory.manager as mgr
@@ -31,35 +32,27 @@ class InventoryShell(shell.ClusterShell):
     def add_subcommands(self, subparsers, revision):
         pass
 
-    @shell.arg('-t','--type', metavar='<type>', help='type of the objects to import, valid values: '+','.join(mgr.InventoryFactory.getvalidobjtypes())+'. '+'If not specified, all objects in the inventory file will be imported')
+    @shell.arg('-t','--type', metavar='<type>', help='comma "," delimited types of the objects to import, valid values: '+','.join(mgr.InventoryFactory.getvalidobjtypes())+'. '+'If not specified, all objects in the inventory file will be imported')
     @shell.arg('-o','--objects', dest='name',metavar='<name>', help='names of the objects to import, delimited with Comma(,). If not specified, all objects of the specified type in the inventory file will be imported')
-    @shell.arg('-f','--path', metavar='<path>', help='path of the inventory file to import ')
+    @shell.arg('-f','--path', metavar='<path>', help='path of the inventory file or directory to import ')
     @shell.arg('-s','--schema-version',dest='version', metavar='<version>', help='schema version of the inventory file. Valid schema versions: '+','.join(mgr.InventoryFactory.getAvailableSchemaVersions())+'. '+'If not specified, the "latest" schema version will be used')
     @shell.arg('--dry', dest='dryrun', action="store_true", default=False, help='Dry run mode, nothing will be commited to xcat database')
     @shell.arg('-c','--clean', dest='update', action="store_false", default=True, help='clean mode. IF specified, all objects other than the ones to import will be removed')
     def do_import(self, args):
         """Import inventory file to xcat database"""
         mgr.validate_args(args, 'import')
-        if args.type :
-            #do export by type
-            mgr.import_by_type(args.type, args.name, args.path, dryrun=args.dryrun,version=args.version,update=args.update)
-        else :
-            mgr.import_all(args.path, dryrun=args.dryrun,version=args.version,update=args.update)
+        mgr.importobj(args.path,args.type,args.name,dryrun=args.dryrun,version=args.version,update=args.update)
 
-    @shell.arg('-t','--type', metavar='<type>', help='type of objects to export, valid values: '+','.join(mgr.InventoryFactory.getvalidobjtypes())+'. '+'If not specified, all objects in xcat databse will be exported')
+    @shell.arg('-t','--type', metavar='<type>', help='comma "," delimited types of objects to export, valid values: '+','.join(mgr.InventoryFactory.getvalidobjtypes())+'. '+'If not specified, all objects in xcat databse will be exported')
     @shell.arg('-x', '--exclude', dest='exclude', default='', help='types to be excluded when exporting all, delimited with Comma(,).')
     @shell.arg('-o','--objects', dest='name',metavar='<name>', help='names of the objects to export, delimited with Comma(,). If not specified, all objects of the specified type will be exported')
-    @shell.arg('-f','--path', metavar='<path>', help='path of the inventory directory(for osimage type only)')
+    @shell.arg('-f','--path', metavar='<path>', help='path of the inventory directory(valid when [-t|--type osimage] is specified or  [-t|--type] is not specified ) or inventory file')
     @shell.arg('-s','--schema-version', dest='version',metavar='<version>', help='schema version of the inventory data. Valid values: '+','.join(mgr.InventoryFactory.getAvailableSchemaVersions())+'. '+'If not specified, the "latest" schema version will be used')
     @shell.arg('--format', metavar='<format>', help='format of the inventory data, valid values: json, yaml. json will be used by default if not specified ')
     def do_export(self, args):
         """Export the inventory data from xcat database"""
         mgr.validate_args(args, 'export')
-        if args.type :
-            # do export by type
-            mgr.export_by_type(args.type, args.name, args.path, args.format, version=args.version)
-        else :
-            mgr.export_all(args.path, args.format, exclude=args.exclude.split(','), version=args.version)
+        mgr.export_by_type(args.type, args.name, args.path, args.format, version=args.version,exclude=args.exclude.split(','))
 
 # main entry for CLI
 def main():

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -34,25 +34,27 @@ class InventoryShell(shell.ClusterShell):
 
     @shell.arg('-t','--type', metavar='<type>', help='comma "," delimited types of the objects to import, valid values: '+','.join(mgr.InventoryFactory.getvalidobjtypes())+'. '+'If not specified, all objects in the inventory file will be imported')
     @shell.arg('-o','--objects', dest='name',metavar='<name>', help='names of the objects to import, delimited with Comma(,). If not specified, all objects of the specified type in the inventory file will be imported')
-    @shell.arg('-f','--path', metavar='<path>', help='path of the inventory file or directory to import ')
+    @shell.arg('-f','--path', metavar='<path>', help='path of the inventory file to import ')
+    @shell.arg('-d','--dir', dest='directory',metavar='<directory>', help='path of the inventory directory')
     @shell.arg('-s','--schema-version',dest='version', metavar='<version>', help='schema version of the inventory file. Valid schema versions: '+','.join(mgr.InventoryFactory.getAvailableSchemaVersions())+'. '+'If not specified, the "latest" schema version will be used')
     @shell.arg('--dry', dest='dryrun', action="store_true", default=False, help='Dry run mode, nothing will be commited to xcat database')
     @shell.arg('-c','--clean', dest='update', action="store_false", default=True, help='clean mode. IF specified, all objects other than the ones to import will be removed')
     def do_import(self, args):
         """Import inventory file to xcat database"""
         mgr.validate_args(args, 'import')
-        mgr.importobj(args.path,args.type,args.name,dryrun=args.dryrun,version=args.version,update=args.update)
+        mgr.importobj(args.path,args.directory,args.type,args.name,dryrun=args.dryrun,version=args.version,update=args.update)
 
     @shell.arg('-t','--type', metavar='<type>', help='comma "," delimited types of objects to export, valid values: '+','.join(mgr.InventoryFactory.getvalidobjtypes())+'. '+'If not specified, all objects in xcat databse will be exported')
     @shell.arg('-x', '--exclude', dest='exclude', default='', help='types to be excluded when exporting all, delimited with Comma(,).')
     @shell.arg('-o','--objects', dest='name',metavar='<name>', help='names of the objects to export, delimited with Comma(,). If not specified, all objects of the specified type will be exported')
-    @shell.arg('-f','--path', metavar='<path>', help='path of the inventory directory(valid when [-t|--type osimage] is specified or  [-t|--type] is not specified ) or inventory file')
+    @shell.arg('-f','--path', metavar='<path>', help='path of the inventory file')
+    @shell.arg('-d','--dir', dest='directory',metavar='<directory>', help='path of the inventory directory')
     @shell.arg('-s','--schema-version', dest='version',metavar='<version>', help='schema version of the inventory data. Valid values: '+','.join(mgr.InventoryFactory.getAvailableSchemaVersions())+'. '+'If not specified, the "latest" schema version will be used')
     @shell.arg('--format', metavar='<format>', help='format of the inventory data, valid values: json, yaml. json will be used by default if not specified ')
     def do_export(self, args):
         """Export the inventory data from xcat database"""
         mgr.validate_args(args, 'export')
-        mgr.export_by_type(args.type, args.name, args.path, args.format, version=args.version,exclude=args.exclude.split(','))
+        mgr.export_by_type(args.type, args.name, args.path,args.directory,args.format, version=args.version,exclude=args.exclude.split(','))
 
 # main entry for CLI
 def main():

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -49,7 +49,7 @@ class InventoryShell(shell.ClusterShell):
     @shell.arg('-t','--type', metavar='<type>', help='type of objects to export, valid values: '+','.join(mgr.InventoryFactory.getvalidobjtypes())+'. '+'If not specified, all objects in xcat databse will be exported')
     @shell.arg('-x', '--exclude', dest='exclude', default='', help='types to be excluded when exporting all, delimited with Comma(,).')
     @shell.arg('-o','--objects', dest='name',metavar='<name>', help='names of the objects to export, delimited with Comma(,). If not specified, all objects of the specified type will be exported')
-    @shell.arg('-f','--path', metavar='<path>', help='path of the inventory file(not implemented yet)')
+    @shell.arg('-f','--path', metavar='<path>', help='path of the inventory directory(for osimage type only)')
     @shell.arg('-s','--schema-version', dest='version',metavar='<version>', help='schema version of the inventory data. Valid values: '+','.join(mgr.InventoryFactory.getAvailableSchemaVersions())+'. '+'If not specified, the "latest" schema version will be used')
     @shell.arg('--format', metavar='<format>', help='format of the inventory data, valid values: json, yaml. json will be used by default if not specified ')
     def do_export(self, args):

--- a/xcat-inventory/xcclient/inventory/vutil.py
+++ b/xcat-inventory/xcclient/inventory/vutil.py
@@ -61,12 +61,14 @@ def isNicips(varin):
                 return False
     return True   
 
+def underpath(filename,path):
+    if re.match(r'^'+os.path.realpath(path)+r'\/',os.path.realpath(filename)):
+        return True
+    else:
+        return False
 
 if __name__ == "__main__":
     pass
-    #expression='x: isRegex(x)'
-    #f=eval("lambda "+expression)
-    #print (f(sys.argv[1]))
     
 
 

--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -218,8 +218,6 @@ class XcatBase(object):
         cls._depdict_tab={}
         cls._depdict_val={}
         cls.__scanschema(cls._schema)
-        #print yaml.dump(cls._depdict_tab,default_flow_style=False)
-        #print yaml.dump(cls._depdict_val,default_flow_style=False)
 
     def __evalschema_tab(self,tabcol):
         mydeptablist=self._depdict_tab[tabcol]['deptablist']
@@ -246,7 +244,6 @@ class XcatBase(object):
                 else:
                     tabvol=self.__evalschema_tab(item)
                     myexpression=myexpression.replace('T{'+item+'}',"'"+str(tabval).replace("'","\\'")+"'")
-        #print "lambda "+myexpression
         evalexp=eval("lambda "+myexpression)
         result=evalexp()
         if myschmpath:
@@ -260,7 +257,6 @@ class XcatBase(object):
             self._dbhash[tabcol]=result
         
     def __evalschema_val(self,valpath):
-        ##print(yaml.dump(self._depdict_val))
         mydeptablist=self._depdict_val[valpath]['deptablist']
         mydepvallist=self._depdict_val[valpath]['depvallist']
         myexpression=self._depdict_val[valpath]['expression']
@@ -279,7 +275,6 @@ class XcatBase(object):
                     myval=''
             myexpression=myexpression.replace('V{'+item+'}',"'"+str(myval).replace("'","\\'")+"'")
         try:
-            #print("lambda "+myexpression)
             evalexp=eval("lambda "+myexpression)
             value=evalexp()
         except Exception,e:
@@ -373,7 +368,6 @@ class XcatBase(object):
                         myval=''
                     myexpression=myexpression.replace('V{'+val+'}',"'"+str(myval).replace("'","\\'")+"'")                    
                 try:
-                    #print myexpression
                     evalexp=eval("lambda "+myexpression)
                     value=evalexp()
                 except Exception,e:                    
@@ -397,7 +391,6 @@ class XcatBase(object):
                         myval=''
                     myexpression=myexpression.replace('V{'+val+'}',"'"+str(myval).replace("'","\\'")+"'")
                 try:
-                    #print("lambda "+myexpression);
                     evalexp=eval("lambda "+myexpression)
                     value=evalexp()
                 except Exception,e:                    

--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -394,7 +394,7 @@ class XcatBase(object):
                     evalexp=eval("lambda "+myexpression)
                     value=evalexp()
                 except Exception,e:                    
-                    raise  InvalidValueException("Error: encountered some error when get the files to save in ["+key+"] of object \""+self.name+"\": "+str(e)) 
+                    raise  InvalidValueException("Error: encountered some error when get the files to save in [%s] of object \"%s\": %s"%(key,self.name,str(e))) 
                 if value:
                     filelist.extend(filter(None,value))
         return filelist


### PR DESCRIPTION
design:
https://github.com/xcat2/xcat-core/wiki/the-mini-design-of-xcat-inventory-export-and-import-for-osimage

for task:
https://github.com/xcat2/xcat2-task-management/issues/128

enhancements:

*  `-t|--type` can be comma delimited types
```
   [root@c910f03c05k21 inventory]# xcat-inventory export -t osimage,zone,passwd 
   [root@c910f03c05k21 inventory]# xcat-inventory import -t osimage,zone,passwd -f /tmp/cluster
```
*  export(dump) inventory data to a file:
```
   [root@c910f03c05k21 inventory]# xcat-inventory export -t osimage,zone,passwd -f /tmp/cluster
```
* export cluster inventory data to a cluster inventory directory:
```
[root@c910f03c05k21 inventory]# xcat-inventory export -d /tmp/mm/
...
Warning: The file "/install/templates/compute/compute.tmpl" of osimage object "compute" does not exist
The osimage objects has been exported to directory /tmp/mm/
The cluster inventory data has been dumped to /tmp/mm//cluster.json
[root@c910f03c05k21 inventory]#  tree -L 3  /tmp/mm
/tmp/mm
├── cluster.json
├── osimage
│   ├── compute
│   │   └── definition.yaml
...
```

under inventory directory:

(1). The file `cluster.json` contains the the cluster objects except `osimage`

(2). The directory `osimage` contains the inventory directories for osimage objects, the osimage inventory directory contains  osimage definition file `definition.yaml` and the osimage customized files(`pkglist`, `template`, `otherpkglist`, `synclists`,`partitionfile`, `exlist`, `postinstall` not under `/opt/xcat/share/xcat/` )  with its path hierarchy in osimage definition


* export osimage objects to inventory directory
```
[root@c910f03c05k21 compute]# xcat-inventory export -t osimage -o compute
{
    "osimage": {
        "compute": {
            "basic_attributes": {
                "arch": "ppc64le",
                "distribution": "rhels6.4",
                "osdistro": "rhels7.3-ppc64le",
                "osname": "linux"
            },
            "imagetype": "linux",
            "package_selection": {
                "otherpkglist": "/install/templates/compute/myotherpkglist",
                "pkgdir": "/install/rhels7.3/x86_64,/install/software/otherpkgs,/install/software/saltstack,/install/software/epel,/install/software/rhel-7-server,/install/software/rhel-7-server-optional-rpms",
                "pkglist": "/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist"
            },
            "provision_mode": "install",
            "role": "compute",
            "template": "/install/templates/compute/compute.tmpl"
        }
    },
    "schema_version": "1.0"
}

[root@c910f03c05k21 compute]# xcat-inventory export -t osimage -o compute -d /tmp/osimages/
The osimage objects has been exported to directory /tmp/osimages/
[root@c910f03c05k21 compute]# tree /tmp/osimages/
/tmp/osimages/
└── compute
    ├── definition.yaml
    └── install
        └── templates
            └── compute
                ├── compute.tmpl
                └── myotherpkglist

4 directories, 3 files
[root@c910f03c05k21 compute]#
```
for osimage `compute`, the `pkglist` file  "/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist" is shipped by xCAT(under `/opt/xcat/share/xcat/`),  the `template` file "/install/templates/compute/compute.tmpl"  and `otherpkglist`   "/install/templates/compute/myotherpkglist" is customized,  from the ` tree /tmp/osimages/`, we can find that only `template` and  `otherpkglist`  are exported to the directory `/tmp/osimages/compute`

* import from cluster inventory directory
```
[root@c910f03c05k21 inventory]# xcat-inventory import -d /tmp/mm/
[root@c910f03c05k21 inventory]# xcat-inventory import -t network,zone -d /tmp/mm/
Importing object: hpctest3
Importing object: management
Importing object: 50_0_0_0-255_0_0_0
Importing object: 192_168_122_0-255_255_255_0
Importing object: 192_168_11_0-255_255_255_0
Importing object: aa
Importing object: xcatdefault
Inventory import successfully!
[root@c910f03c05k21 inventory]# xcat-inventory import -t osimage -o rhels6.4-ppc64le-install-compute  -d /tmp/mm/
Importing object: rhels6.4-ppc64le-install-compute
Inventory import successfully!
The object rhels6.4-ppc64le-install-compute has been imported
```

* import osimages from osimage inventory directory
```
[root@c910f03c05k21 inventory]# xcat-inventory import -t osimage -o rhels7.4-ppc64le-install-compute  -d /tmp/osimages/rhels7.4-ppc64le-install-compute/
Importing object: rhels7.4-ppc64le-install-compute
Inventory import successfully!
The object rhels7.4-ppc64le-install-compute has been imported
```
all the osimage customized files will be copied to the paths in the osimage definition