### PR TITLE
fix debian packaging error

### DIFF
--- a/xcat-inventory/debian/dirs
+++ b/xcat-inventory/debian/dirs
@@ -1,6 +1,5 @@
 opt/xcat/bin
 opt/xcat/lib/python/xcclient
 opt/xcat/lib/python/xcclient/inventory
-opt/xcat/lib/python/xcclient/inventory/schema/latest
 opt/xcat/lib/python/xcclient/inventory/schema/1.0
 opt/xcat/share/xcat/inventory_templates


### PR DESCRIPTION
#29 
After fix, UT:
```
root@c910f03c05k10:~/level0/level1/level2/xcat-inventory# ./build-ubuntu -c
###############################
# Building xcat-inventory package #
###############################
............
dpkg-deb: building package 'xcat-inventory' in '../xcat-inventory_0.1.2-snap201805150113_all.deb'.
pwd
/root/level0/level1/level2/xcat-inventory/xcat-inventory
 dpkg-genchanges  >../xcat-inventory_0.1.2-snap201805150113_ppc64el.changes
dpkg-genchanges: warning: the current version (0.1.2-snap201805150113) is earlier than the previous one (2.9.13-1)
dpkg-genchanges: including full source code in upload
 dpkg-source --after-build xcat-inventory
dpkg-buildpackage: full upload; Debian-native package (full source is included)
/root/level0/level1/level2/xcat-inventory

root@c910f03c05k10:~/level0/level1/level2/xcat-inventory# dpkg -l |grep xcat-inventory

root@c910f03c05k10:~/level0/level1/level2/xcat-inventory# dpkg -i xcat-inventory_0.1.2-snap201805150113_all.deb
Selecting previously unselected package xcat-inventory.
(Reading database ... 108200 files and directories currently installed.)
Preparing to unpack xcat-inventory_0.1.2-snap201805150113_all.deb ...
Unpacking xcat-inventory (0.1.2-snap201805150113) ...
Setting up xcat-inventory (0.1.2-snap201805150113) ...

root@c910f03c05k10:~/level0/level1/level2/xcat-inventory# ls /opt/xcat/lib/python/xcclient/inventory/schema/latest
network.yaml  node.yaml  osimage.yaml  passwd.yaml  policy.yaml  route.yaml  site.yaml  zone.yaml
root@c910f03c05k10:~/level0/level1/level2/xcat-inventory# ls -l /opt/xcat/lib/python/xcclient/inventory/schema/latest
lrwxrwxrwx 1 root root 3 May 15 01:13 /opt/xcat/lib/python/xcclient/inventory/schema/latest -> 1.0
```