### PR TITLE
refine the message format to more pythonic; add dryrun support for import

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -358,18 +358,24 @@ def importobjdir(location,dryrun=None,version=None,update=True):
     for myfile in objfiles:
         srcfile=location+myfile
         if os.path.exists(srcfile):
-            try:
-                os.makedirs(os.path.dirname(myfile))
-            except OSError, e:
-                if e.errno != os.errno.EEXIST:
-                    raise
-                pass
+            if dryrun:
+                print("creating directory: %s. Dryrun mode, do nothing..."%(os.path.dirname(myfile)))
+            else:
+                try:
+                    os.makedirs(os.path.dirname(myfile))
+                except OSError, e:
+                    if e.errno != os.errno.EEXIST:
+                        raise
+                    pass
             if os.path.exists(myfile):
-                print("Warning: the "+myfile+" already exists, will be overwritten", file=sys.stderr)
-            if os.path.samefile(srcfile,myfile):
+                print("Warning: the %s already exists, will be overwritten"%(myfile), file=sys.stderr)
+            if os.path.exists(myfile) and os.path.samefile(srcfile,myfile):
                 print("Warning: \"%s\" and \"%s\" are the same file, skip copy"%(srcfile,myfile),file=sys.stderr)
             else:
-                shutil.copyfile(srcfile,myfile)
+                if dryrun:
+                    print("copying file: %s ----> %s. Dryrun mode, do nothing..."%(srcfile,myfile))
+                else:
+                    shutil.copyfile(srcfile,myfile)
         else:
             print("Warning: the file \""+srcfile+"\" of osimage \""+objname+"\" does not exist!",file=sys.stderr)
     print("The object "+objname+" has been imported")


### PR DESCRIPTION
* refine the message format to more pythonic; 
* add dryrun support for import


UT:

```
[root@c910f03c05k21 xCAT-Incubator]# xcat-inventory import -d /tmp/mm/osimage/rhels7.4-ppc64le-install-compute  --dry
Importing object: rhels7.4-ppc64le-install-compute
Dry run mode, nothing will be written to database!
creating directory: /tmp. Dryrun mode, do nothing...
copying file: /tmp/mm/osimage/rhels7.4-ppc64le-install-compute/tmp/synclists ----> /tmp/synclists. Dryrun mode, do nothing...
The object rhels7.4-ppc64le-install-compute has been imported
[root@c910f03c05k21 xCAT-Incubator]# lsdef -t osimage -o rhels7.4-ppc64le-install-compute
Error: Could not find an object named 'rhels7.4-ppc64le-install-compute' of type 'osimage'.
[root@c910f03c05k21 xCAT-Incubator]# ls /tmp/synclists
ls: cannot access /tmp/synclists: No such file or directory
[root@c910f03c05k21 xCAT-Incubator]#
```