### PR TITLE
add more strict check on -f|--path

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -184,8 +184,17 @@ def validate_args(args, action):
             raise CommandException("Error: the specified directory %(d)s does not exist!", d=args.directory)
         if not os.path.isdir(args.directory):
             raise CommandException("Error: the specified directory %(d)s is not a directory!", d=args.directory)
-    if args.path and os.path.exists(args.path) and not os.path.isfile(args.path):
-            raise CommandException("Error: the specified file %(f)s already exists, is not a file!", f=args.path)
+    if args.path:
+        if os.path.exists(args.path):
+            if not os.path.isfile(args.path):
+                raise CommandException("Error: the specified file %(f)s already exists, is not a file!", f=args.path)
+        else:
+            mydir=os.path.dirname(args.path)
+            myfile=os.path.basename(args.path)
+            if not myfile:
+                raise CommandException("Error: %(f)s is not a file!", f=args.path)
+            if not os.path.isdir(mydir):
+                raise CommandException("Error: the directory %(f)s does not exist or is not a directory!", f=mydir)
        
     
     if action == 'import': #extra validation for export


### PR DESCRIPTION
UT:

```
[root@c910f03c05k21 inventory]# xcat-inventory export -t osimage -o rhels7.4-ppc64le-install-service  -d /tmp/kkk/mmm/nnn
Error: the specified directory /tmp/kkk/mmm/nnn does not exist!
[root@c910f03c05k21 inventory]# xcat-inventory export -f /tmp/aaa/
Error: /tmp/aaa/ is not a file!
```