### PR TITLE
add xcat version in exported definition

### DIFF
--- a/xcat-inventory/xcclient/inventory/utils.py
+++ b/xcat-inventory/xcclient/inventory/utils.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+###############################################################################
+# IBM(c) 2007 EPL license http://www.eclipse.org/legal/epl-v10.html
+###############################################################################
+# -*- coding: utf-8 -*-
+# common helper subroutines
+#
+import os
+import subprocess
+
+def runCommand(cmd, env=None):
+    """
+    Run one command only, when you don't want to bother setting up
+    the Popen stuff.
+        (retcode,out,err)=runCommand('lsxcatd -v')
+    """
+    try:
+        p = subprocess.Popen(cmd,
+        env=env,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+        out, err = p.communicate()
+    except OSError,e:
+        return p.returncode,out, err
+    return p.returncode,out, err
+
+


### PR DESCRIPTION
for issue https://github.com/xcat2/xcat-inventory/issues/35
* add xcat version in exported definition 
UT:
```
[root@c910f03c05k21 xcclient]# xcat-inventory export -t osimage -o compute --format yaml
osimage:
  compute:
    basic_attributes:
      arch: ppc64le
      distribution: rhels6.4
      osdistro: rhels7.3-ppc64le
      osname: linux
    imagetype: linux
    package_selection:
      otherpkglist: /install/templates/compute/myotherpkglist
      pkgdir: /install/rhels7.3/x86_64,/install/software/otherpkgs,/install/software/saltstack,/install/software/epel,/install/software/rhel-7-server,/install/software/rhel-7-server-optional-rpms
      pkglist: /opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist
    provision_mode: install
    role: compute
    template: /install/templates/compute/compute.tmpl
schema_version: '1.0'

#Version 2.14.1 (git commit ac941fd2501e8a581bfcc4c79b9301f6ec37ab93, built Mon May 21 06:15:46 EDT 2018)
```