### PR TITLE
set the default format to json in export_by_type

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -95,7 +95,6 @@ class InventoryFactory(object):
                 if os.path.exists(mydir):
                     shutil.rmtree(mydir)
                 os.mkdir(mydir) 
-                myfile=os.path.join(mydir,'definition.yaml')
                 if fmt=='yaml':
                     myfile=os.path.join(mydir,'definition.yaml')
                 elif fmt=='json':
@@ -228,6 +227,8 @@ def export_by_type(objtype, names, destfile=None, destdir=None, fmt='json',versi
     if objtype and objtype != 'osimage' and destdir:
         raise CommandException("Error: directory %(f)s specified by -f|--path is only supported when [-t|--type osimage] or export all without [-t|--type] specified",f=destdir)
 
+    if not fmt:
+        fmt='json'
     InventoryFactory.getLatestSchemaVersion()
     dbsession=DBsession()
     


### PR DESCRIPTION
set the default format to json in export_by_type

UT:
before this fix:
```
[root@c910f03c05k21 templates]# xcat-inventory export -t osimage -o test_myimage -d /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/
The osimage objects has been exported to directory /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/
[root@c910f03c05k21 templates]# tree /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/test_myimage/
/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/test_myimage/
├── definition.yaml
└── tmp
    ├── exlist
    ├── otherpkglist
    ├── partitionfile
    ├── postinstall
    └── synclists

1 directory, 6 files
[root@c910f03c05k21 templates]# cat /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/test_myimage/definition.yaml
{
    "osimage": {
        "test_myimage": {
            "diskpartitionspec": "/tmp/partitionfile",
            "filestosync": "/tmp/synclists",
            "genimgoptions": {
                "exlist": "/tmp/exlist",
                "postinstall": "/tmp/postinstall"
            },
            "imagetype": "linux",
            "package_selection": {
                "otherpkglist": "/tmp/otherpkglist",
                "pkglist": "/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist"
            },
            "provision_mode": "install",
            "template": "/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl"
        }
    },
    "schema_version": "1.0"
}
#Version 2.14.1 (git commit ac941fd2501e8a581bfcc4c79b9301f6ec37ab93, built Mon May 21 06:15:46 EDT 2018)
You have new mail in /var/spool/mail/root
```

after this fix:

```
[root@c910f03c05k21 templates]# xcat-inventory export -t osimage -o test_myimage -d /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/
The osimage objects has been exported to directory /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/
[root@c910f03c05k21 templates]# tree /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/test_myimage/
/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/test_myimage/
├── definition.json
└── tmp
    ├── exlist
    ├── otherpkglist
    ├── partitionfile
    ├── postinstall
    └── synclists

1 directory, 6 files
[root@c910f03c05k21 templates]# cat /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/test_myimage/definition.json
{
    "osimage": {
        "test_myimage": {
            "diskpartitionspec": "/tmp/partitionfile",
            "filestosync": "/tmp/synclists",
            "genimgoptions": {
                "exlist": "/tmp/exlist",
                "postinstall": "/tmp/postinstall"
            },
            "imagetype": "linux",
            "package_selection": {
                "otherpkglist": "/tmp/otherpkglist",
                "pkglist": "/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist"
            },
            "provision_mode": "install",
            "template": "/opt/xcat/share/xcat/install/rh/compute.rhels7.tmpl"
        }
    },
    "schema_version": "1.0"
}
#Version 2.14.1 (git commit ac941fd2501e8a581bfcc4c79b9301f6ec37ab93, built Mon May 21 06:15:46 EDT 2018)
You have new mail in /var/spool/mail/root
```