### PR TITLE
add support for relative path in osimage inventory[DO NOT MERGE]

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -126,7 +126,7 @@ class InventoryFactory(object):
             raise InvalidFileException("Error: invalid keys found \""+' '.join(invalidkeys)+"\"!")
         
         
-    def importObjs(self, objlist, obj_attr_dict,update=True):
+    def importObjs(self, objlist, obj_attr_dict,update=True,path=None):
         myclass = InventoryFactory.__InventoryClass__[self.objtype]
         myclass.loadschema(self.schemapath)
         dbdict = {}
@@ -134,12 +134,13 @@ class InventoryFactory(object):
         for key, attrs in obj_attr_dict.items():
             if not objlist or key in objlist:
                 newobj = myclass.createfromfile(key, attrs)
-                objfiles[key]=newobj.getfilestosave()
+                objfiles[key]=newobj.getfilestosave(path)
                 dbdict.update(newobj.getdbdata())
         tabs=myclass.gettablist()
         if not update:
             self.getDBInst().cleartab(tabs)
         self.getDBInst().settab(dbdict)
+        print(objfiles)
         return objfiles
 
     def getcurschemaversion(self):
@@ -345,13 +346,13 @@ def importfromfile(objtypelist, objlist, location,dryrun=None,version=None,updat
             hdl = InventoryFactory.createHandler(myobjtype,dbsession,version)
             if myobjtype not in objfiledict.keys():
                 objfiledict[myobjtype]={}
-            objfiledict[myobjtype].update(hdl.importObjs(objlist, obj_attr_dict[myobjtype],update))
+            objfiledict[myobjtype].update(hdl.importObjs(objlist, obj_attr_dict[myobjtype],update,os.path.dirname(location)))
     else:
         for objtype in obj_attr_dict.keys():#VALID_OBJ_TYPES:
             hdl = InventoryFactory.createHandler(objtype,dbsession,version)
             if objtype not in objfiledict.keys():
                 objfiledict[objtype]={}
-            objfiledict[objtype].update(hdl.importObjs([], obj_attr_dict[objtype],update))
+            objfiledict[objtype].update(hdl.importObjs([], obj_attr_dict[objtype],update,os.path.dirname(location)))
 
     if not dryrun:
         try:


### PR DESCRIPTION
* support the import of osimage inventory data with relative paths
UT:

we have a osimage named "compute", the definition as well as all osimage files are placed under the osimage derectory `/home/yangsbj/compute/`, the customized files in the osimage "definition.json"  are referred with relative paths.
```
[root@c910f03c05k21 compute]# cd /home/yangsbj/compute/
[root@c910f03c05k21 compute]# cat ./definition.json
{
    "osimage": {
        "compute": {
            "basic_attributes": {
                "arch": "ppc64le",
                "distribution": "rhels6.4",
                "osdistro": "rhels7.3-ppc64le",
                "osname": "linux"
            },
            "imagetype": "linux",
            "package_selection": {
                "otherpkglist": "compute/myotherpkglist",
                "pkgdir": "/install/rhels7.3/x86_64,/install/software/otherpkgs,/install/software/saltstack,/install/software/epel,/install/software/rhel-7-server,/install/software/rhel-7-server-optional-rpms",
                "pkglist": "/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist"
            },
            "provision_mode": "install",
            "role": "compute",
            "template": "compute/compute.tmpl"
        }
    },
    "schema_version": "1.0"
}
#Version 2.14.1 (git commit ac941fd2501e8a581bfcc4c79b9301f6ec37ab93, built Mon May 21 06:15:46 EDT 2018)
[root@c910f03c05k21 compute]#

```


import the osimage definition,  the real paths of the customized files are filled in the osimage definition: 
```
[root@c910f03c05k21 compute]# xcat-inventory import -f /home/yangsbj/compute/definition.yaml
Importing object: compute
Inventory import successfully!
[root@c910f03c05k21 compute]# lsdef -t osimage -o compute
Object name: compute
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.3-ppc64le
    osname=linux
    osvers=rhels6.4
    otherpkglist=/home/yangsbj/compute/compute/myotherpkglist
    pkgdir=/install/rhels7.3/x86_64,/install/software/otherpkgs,/install/software/saltstack,/install/software/epel,/install/software/rhel-7-server,/install/software/rhel-7-server-optional-rpms
    pkglist=/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist
    profile=compute
    provmethod=install
    template=/home/yangsbj/compute/compute/compute.tmpl
```

we can use run commands against the osimage `compute ` directly without any explicit/implicite file copy