### PR TITLE
export/import the files included in osimage customized files in osimage definition

### DIFF
--- a/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
@@ -21,11 +21,11 @@
     package_selection:
       pkglist: 
       - "T{linuximage.pkglist}"
-      - "F:${{flist=V{package_selection.pkglist}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
+      - "F:${{flist=V{package_selection.pkglist}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
       pkgdir: "T{linuximage.pkgdir}"
       otherpkglist: 
       - "T{linuximage.otherpkglist}"
-      - "F:${{flist=V{package_selection.otherpkglist}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
+      - "F:${{flist=V{package_selection.otherpkglist}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       otherpkgdir: "T{linuximage.otherpkgdir}"
     osupdatename: "T{osimage.osupdatename}"
     kernel_driver:
@@ -34,30 +34,32 @@
       kerneldir: "T{linuximage.kerneldir}"
       kernelver: "T{linuximage.kernelver}"
     scripts:
-      postscripts: "T{osimage.postscripts}"
-      postbootscripts: "T{osimage.postbootscripts}"
+      postscripts: 
+      - "T{osimage.postscripts}"
+      postbootscripts: 
+      - "T{osimage.postbootscripts}"
     kernel_dump:
       dump: "T{linuximage.dump}"
       crashkernelsize: "T{linuximage.crashkernelsize}"
     template: 
     - "${{imagetype=V{imagetype} :T{winimage.template} if imagetype == 'windows' else T{linuximage.template} if imagetype == 'linux' else None }} "
-    - "F:${{flist=V{template}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
+    - "F:${{flist=V{template}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
       
     diskpartitionspec: 
     - "${{imagetype=V{imagetype} :T{linuximage.partitionfile} if imagetype == 'linux' else T{winimage.partitionfile} if imagetype == 'windows' else None}}"
-    - "F:${{flist=V{diskpartitionspec}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
+    - "F:${{flist=V{diskpartitionspec}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
     filestosync: 
     - "T{osimage.synclists}"
-    - "F:${{flist=V{filestosync}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
+    - "F:${{flist=V{filestosync}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
     addkcmdline: "T{linuximage.addkcmdline}"
     boottarget: "T{linuximage.boottarget}"                                 
     genimgoptions:
       exlist: 
       - "T{linuximage.exlist}"
-      - "F:${{flist=V{genimgoptions.exlist}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
+      - "F:${{flist=V{genimgoptions.exlist}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       postinstall: 
       - "T{linuximage.postinstall}"
-      - "F:${{flist=V{genimgoptions.postinstall}.split(','): [x for x in flist if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
+      - "F:${{flist=V{genimgoptions.postinstall}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       rootimgdir: "T{linuximage.rootimgdir}"
       nodebootif: "T{linuximage.nodebootif}"
       permission: "T{linuximage.permission}"

--- a/xcat-inventory/xcclient/inventory/vutil.py
+++ b/xcat-inventory/xcclient/inventory/vutil.py
@@ -67,6 +67,36 @@ def underpath(filename,path):
     else:
         return False
 
+
+# return a list of the files in list "infilelist" and the files included in them
+def getfileanddeplist(infilelist):
+    #helper function to return a dict whose keys are file "filename" specified and files included by it 
+    def getincfiledict(filename,filedict={}):
+        regex_include=r'^#INCLUDE:([^#]+)#$'
+        if filename in filedict.keys():
+            return
+        filedict[filename]=1
+        if os.path.isfile(filename):
+            with open(filename) as fileobj:
+                filelines = fileobj.readlines()
+            olddir=os.getcwd()
+            curdir=os.path.dirname(filename)
+            os.chdir(curdir)
+            for line in filelines:
+                matchobj_include=re.search(regex_include,line.strip()) 
+                if matchobj_include:
+                    incfile=matchobj_include.group(1)
+                    incfile=os.path.realpath(incfile)
+                    if incfile not in filedict.keys():
+                        getincfiledict(incfile,filedict)
+            os.chdir(olddir)
+        return 
+
+    filedict={}
+    for filename in infilelist:
+        getincfiledict(filename,filedict)
+    return filedict.keys()
+
 if __name__ == "__main__":
     pass
     


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-inventory/issues/32:

UT:
```
[root@c910f03c05k21 inventory]# lsdef -t osimage -o compute
Object name: compute
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.3-ppc64le
    osname=linux
    osvers=rhels6.4
    otherpkglist=/home/yangsbj/compute/compute/myotherpkglist
    pkgdir=/install/rhels7.3/x86_64,/install/software/otherpkgs,/install/software/saltstack,/install/software/epel,/install/software/rhel-7-server,/install/software/rhel-7-server-optional-rpms
    pkglist=/opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist
    profile=compute
    provmethod=install
    template=/home/yangsbj/compute/compute/compute.tmpl
[root@c910f03c05k21 inventory]# cat /home/yangsbj/compute/compute/compute.tmpl
#INCLUDE:/tmp/yy#
[root@c910f03c05k21 inventory]# cat /home/yangsbj/compute/compute/myotherpkglist
[root@c910f03c05k21 inventory]# cat /opt/xcat/share/xcat/install/rh/compute.rhels7.pkglist
#Please make sure there is a space between @ and group name
wget
ntp
nfs-utils
net-snmp
rsync
yp-tools
openssh-server
util-linux
net-tools
#INCLUDE:/tmp/zz#
#INCLUDE:/opt/xcat/share/xcat/install/rh/compute.rhels6.pkglist#
[root@c910f03c05k21 inventory]#

```

then export the osimage:

```
[root@c910f03c05k21 inventory]# xcat-inventory export -t osimage -o compute -d /tmp/osimages/
The osimage objects has been exported to directory /tmp/osimages/
[root@c910f03c05k21 inventory]# tree /tmp/osimages/compute
/tmp/osimages/compute
├── definition.json
├── home
│   └── yangsbj
│       └── compute
│           └── compute
│               ├── compute.tmpl
│               └── myotherpkglist
└── tmp
    ├── yy
    └── zz

5 directories, 5 files
```

All the included files are exported