### PR TITLE
support environment variables in osimage inventory data and files

### DIFF
--- a/xcat-inventory/debian/control
+++ b/xcat-inventory/debian/control
@@ -8,5 +8,5 @@ Homepage: https://xcat.org/
 
 Package: xcat-inventory
 Architecture: all
-Depends: python-pymysql,python-sqlalchemy,python-psycopg2,python-six,python-yaml
+Depends: python-pymysql,python-sqlalchemy,python-psycopg2,python-six,python-yaml,python-jinja2
 Description: xcat inventory

--- a/xcat-inventory/requirements.txt
+++ b/xcat-inventory/requirements.txt
@@ -2,3 +2,4 @@ pyyaml
 pymysql
 sqlalchemy
 psycopg2
+jinja2

--- a/xcat-inventory/xcat-inventory.spec
+++ b/xcat-inventory/xcat-inventory.spec
@@ -11,7 +11,7 @@ Vendor: IBM Corp.
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
 Prefix: /opt/xcat
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
-Requires: python-psycopg2 python-sqlalchemy >= 0.8.0 MySQL-python PyYAML python-six
+Requires: python-psycopg2 python-sqlalchemy >= 0.8.0 MySQL-python PyYAML python-six python-jinja2
 
 %ifos linux
 BuildArch: noarch

--- a/xcat-inventory/xcclient/inventory/exceptions.py
+++ b/xcat-inventory/xcclient/inventory/exceptions.py
@@ -41,3 +41,5 @@ class BadSchemaException(BaseException):
     pass
 class DBException(BaseException):
     pass
+class ParseException(BaseException):
+    pass

--- a/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
@@ -38,6 +38,7 @@
       - "T{osimage.postscripts}"
       postbootscripts: 
       - "T{osimage.postbootscripts}"
+    environvars: "T{osimage.environvar}"
     kernel_dump:
       dump: "T{linuximage.dump}"
       crashkernelsize: "T{linuximage.crashkernelsize}"

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -63,7 +63,7 @@ def main():
     except KeyboardInterrupt:
         print("... terminating xCAT inventory management tool", file=sys.stderr)
         sys.exit(2)
-    except (InvalidFileException,ObjNonExistException,CommandException,InvalidValueException,BadDBHdlException,BadSchemaException,DBException), e:
+    except (InvalidFileException,ObjNonExistException,CommandException,InvalidValueException,BadDBHdlException,BadSchemaException,DBException,ParseException), e:
         print(str(e), file=sys.stderr)
         sys.exit(1)
     #except (ParserError), e:

--- a/xcat-inventory/xcclient/inventory/utils.py
+++ b/xcat-inventory/xcclient/inventory/utils.py
@@ -6,6 +6,7 @@
 # common helper subroutines
 #
 import os
+import re
 import subprocess
 
 def runCommand(cmd, env=None):
@@ -25,4 +26,44 @@ def runCommand(cmd, env=None):
         return p.returncode,out, err
     return p.returncode,out, err
 
+#remove the dict entries whose value is null or ''
+def Util_rmnullindict(mydict):
+    for key in mydict.keys():
+        if isinstance(mydict[key],dict):
+            Util_rmnullindict(mydict[key])
+            if not mydict[key].keys():
+                del mydict[key]
+        else:
+            if not mydict[key]:
+                del mydict[key]
+
+
+
+# get the dict value mydict[a][b][c] with key path a.b.c
+def Util_getdictval(mydict,keystr):
+    if not  isinstance(mydict,dict):
+        return None
+    dictkeyregex=re.compile("([^\.]+)\.?(\S+)*")
+    result=re.findall(dictkeyregex,keystr)
+    if result:
+        (key,remdkey)=result[0]
+        if key not in mydict.keys():
+            return None
+        if remdkey:
+            return Util_getdictval(mydict[key],remdkey)
+        else:
+            return mydict[key]
+
+# get the dict value mydict[a][b][c] with key path a.b.c
+def Util_setdictval(mydict,keystr,value):
+    dictkeyregex=re.compile("([^\.]+)\.?(\S+)*")
+    result=re.findall(dictkeyregex,keystr)
+    if result:
+        (key,remdkey)=result[0]
+        if remdkey:
+            if key not in mydict.keys():
+                mydict[key]={}
+            Util_setdictval(mydict[key],remdkey,value)
+        else:
+            mydict[key]=value
 

--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -12,49 +12,11 @@ from copy import *
 from dbobject import *
 from dbfactory import *
 from exceptions import *
+from utils import *
 import vutil
 import pdb
 
-#remove the dict entries whose value is null or ''
-def Util_rmnullindict(mydict):
-    for key in mydict.keys():
-        if isinstance(mydict[key],dict):
-            Util_rmnullindict(mydict[key])
-            if not mydict[key].keys():
-                del mydict[key]
-        else:
-            if not mydict[key]:
-                del mydict[key]
 
-
-
-# get the dict value mydict[a][b][c] with key path a.b.c
-def Util_getdictval(mydict,keystr):
-    if not  isinstance(mydict,dict):
-        return None
-    dictkeyregex=re.compile("([^\.]+)\.?(\S+)*")
-    result=re.findall(dictkeyregex,keystr)
-    if result:
-        (key,remdkey)=result[0]
-        if key not in mydict.keys():
-            return None
-        if remdkey:
-            return Util_getdictval(mydict[key],remdkey)
-        else:
-            return mydict[key]
-
-# get the dict value mydict[a][b][c] with key path a.b.c
-def Util_setdictval(mydict,keystr,value):
-    dictkeyregex=re.compile("([^\.]+)\.?(\S+)*")
-    result=re.findall(dictkeyregex,keystr)
-    if result:
-        (key,remdkey)=result[0]
-        if remdkey:
-            if key not in mydict.keys():
-                mydict[key]={}      
-            Util_setdictval(mydict[key],remdkey,value)
-        else:
-            mydict[key]=value
 
 
 class XcatBase(object):


### PR DESCRIPTION
for feature https://github.com/xcat2/xcat-inventory/issues/44:

UT:
the git directory `/git/xcat_clusters` is a fork from repo https://github.ibm.com/yangsbj/xcat_clusters, the osimage inventory file  `ist.redhat.perf.custom.netboot.DL.osimage.yaml` includes 2 environment variables:
* {{GITREPO}}: the path to the git dir. if the environment variable `GITREPO` does not exist, will detect the git root directory of the specified inventory file `ist.redhat.perf.custom.netboot.DL.osimage.yaml`
* {{SWDIR}}: the path to the shared SW directory. if the environment variable `SWDIR `  does not exist, will take `/install/REPO` as default value

```
[root@c910f03c05k21 rhels]# pwd
/git/xcat_clusters/osimage/rhels
[root@c910f03c05k21 rhels]# cat ./ist.redhat.perf.custom.netboot.DL.osimage.yaml
# Metadata
# tags: ist
# source osimage: rhels7.5-SP1.1.1819b.perf
osimage:
  ist.redhat.perf.custom.netboot.DL:
    basic_attributes:
      arch: ppc64le
      distribution: rhels7.5
      osdistro: rhels7.5-ppc64le
      osname: Linux
    filestosync: {{GITREPO}}/osimage/rhels/syncfiles/synclist
    deprecated:
      comments: rhels7.5,ist,cida-396.27,mofed-3-2.2.2.5
    genimgoptions:
      permission: '755'
      postinstall: {{GITREPO}}/osimage/rhels/common/postinstall/MOFED.postinstall,{{GITREPO}}/osimage/rhels/common/postinstall/CSM.postinstall,{{GITREPO}}/osimage/rhels/common/postinstall/compute.postinstall
      rootimgdir: /install/custom/ist.perf.custom.netboot.DL
    imagetype: linux
    package_selection:
      otherpkgdir: {{SWDIR}}/software
      otherpkglist: {{GITREPO}}/osimage/rhels/common/otherpkglist/essl.otherpkglist,{{GITREPO}}/osimage/rhels/common/otherpkglist/pessl.otherpkglist,{{GITREPO}}/osimage/rhels/common/otherpkglist/xlc.otherpkglist,{{GITREPO}}/osimage/rhels/common/otherpkglist/xlf.otherpkglist,{{GITREPO}}/osimage/rhels/common/otherpkglist/PPT.otherpkglist,{{GITREPO}}/osimage/rhels/common/otherpkglist/SMPI.otherpkglist,{{GITREPO}}/osimage/rhels/common/otherpkglist/cuda.otherpkglist
      pkgdir: {{SWDIR}}/os/rhels/rhels7.5-rc3/ppc64le,{{SWDIR}}/software/nvidia/cuda-dep/repo/ppc64le/,{{SWDIR}}/os/rhels7.5-alt/kernels/kernel-alt-4.14.0-49.3.1.el7a.ibmnvidia.5.ppc64le
      pkglist: {{GITREPO}}/osimage/rhels/common/pkglist/all.pkglist,{{GITREPO}}/osimage/rhels/common/pkglist/cuda.pkglist,{{GITREPO}}/osimage/rhels/common/pkglist/ib.pkglist
    provision_mode: netboot
    role: compute
schema_version: '1.0'
```

let's import the osimage definition:
```
[root@c910f03c05k21 rhels]# xcat-inventory import -f ./ist.redhat.perf.custom.netboot.DL.osimage.yaml
Importing object: ist.redhat.perf.custom.netboot.DL
Inventory import successfully!
[root@c910f03c05k21 rhels]# lsdef -t osimage -o ist.redhat.perf.custom.netboot.DL
Object name: ist.redhat.perf.custom.netboot.DL
    environvar=GITREPO=/git/xcat_clusters,SWDIR=/install/REPO
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.5-ppc64le
    osname=Linux
    osvers=rhels7.5
    otherpkgdir=/install/REPO/software
    otherpkglist=/git/xcat_clusters/osimage/rhels/common/otherpkglist/essl.otherpkglist,/git/xcat_clusters/osimage/rhels/common/otherpkglist/pessl.otherpkglist,/git/xcat_clusters/osimage/rhels/common/otherpkglist/xlc.otherpkglist,/git/xcat_clusters/osimage/rhels/common/otherpkglist/xlf.otherpkglist,/git/xcat_clusters/osimage/rhels/common/otherpkglist/PPT.otherpkglist,/git/xcat_clusters/osimage/rhels/common/otherpkglist/SMPI.otherpkglist,/git/xcat_clusters/osimage/rhels/common/otherpkglist/cuda.otherpkglist
    permission=755
    pkgdir=/install/REPO/os/rhels/rhels7.5-rc3/ppc64le,/install/REPO/software/nvidia/cuda-dep/repo/ppc64le/,/install/REPO/os/rhels7.5-alt/kernels/kernel-alt-4.14.0-49.3.1.el7a.ibmnvidia.5.ppc64le
    pkglist=/git/xcat_clusters/osimage/rhels/common/pkglist/all.pkglist,/git/xcat_clusters/osimage/rhels/common/pkglist/cuda.pkglist,/git/xcat_clusters/osimage/rhels/common/pkglist/ib.pkglist
    postinstall=/git/xcat_clusters/osimage/rhels/common/postinstall/MOFED.postinstall,/git/xcat_clusters/osimage/rhels/common/postinstall/CSM.postinstall,/git/xcat_clusters/osimage/rhels/common/postinstall/compute.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/custom/ist.perf.custom.netboot.DL
    synclists=/git/xcat_clusters/osimage/rhels/syncfiles/synclist
    usercomment=rhels7.5,ist,cida-396.27,mofed-3-2.2.2.5
```

we can find that environment variables in osimage inventory file has been automatically replaced with default values, and the environment variables are save in attribute "environvar" of osimage definition in xCATDB, which will be used to resolve the environment variables used in osimage customized files such as postinstall scripts 

Now let's specify the values for the 2 environment variables when import the osimage inventory file:
```
[root@c910f03c05k21 rhels]# export GITREPO="/git/xcat_clusters"
[root@c910f03c05k21 rhels]# export SWDIR="/install/REPO"
[root@c910f03c05k21 rhels]# xcat-inventory import -f ./ist.redhat.perf.custom.netboot.DL.osimage.yaml
Importing object: ist.redhat.perf.custom.netboot.DL
Inventory import successfully!
[root@c910f03c05k21 rhels]# lsdef -t osimage -o ist.redhat.perf.custom.netboot.DL
Object name: ist.redhat.perf.custom.netboot.DL
    environvar=GITREPO=/git/xcat_clusters,SWDIR=/install/REPO
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.5-ppc64le
    osname=Linux
    osvers=rhels7.5
    otherpkgdir=/install/REPO/software
    otherpkglist=/git/xcat_clusters/osimage/rhels/common/otherpkglist/essl.otherpkglist,/git/xcat_clusters/osimage/rhels/common/otherpkglist/pessl.otherpkglist,/git/xcat_clusters/osimage/rhels/common/otherpkglist/xlc.otherpkglist,/git/xcat_clusters/osimage/rhels/common/otherpkglist/xlf.otherpkglist,/git/xcat_clusters/osimage/rhels/common/otherpkglist/PPT.otherpkglist,/git/xcat_clusters/osimage/rhels/common/otherpkglist/SMPI.otherpkglist,/git/xcat_clusters/osimage/rhels/common/otherpkglist/cuda.otherpkglist
    permission=755
    pkgdir=/install/REPO/os/rhels/rhels7.5-rc3/ppc64le,/install/REPO/software/nvidia/cuda-dep/repo/ppc64le/,/install/REPO/os/rhels7.5-alt/kernels/kernel-alt-4.14.0-49.3.1.el7a.ibmnvidia.5.ppc64le
    pkglist=/git/xcat_clusters/osimage/rhels/common/pkglist/all.pkglist,/git/xcat_clusters/osimage/rhels/common/pkglist/cuda.pkglist,/git/xcat_clusters/osimage/rhels/common/pkglist/ib.pkglist
    postinstall=/git/xcat_clusters/osimage/rhels/common/postinstall/MOFED.postinstall,/git/xcat_clusters/osimage/rhels/common/postinstall/CSM.postinstall,/git/xcat_clusters/osimage/rhels/common/postinstall/compute.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/custom/ist.perf.custom.netboot.DL
    synclists=/git/xcat_clusters/osimage/rhels/syncfiles/synclist
    usercomment=rhels7.5,ist,cida-396.27,mofed-3-2.2.2.5
```
we can find that the environment variables are replaced with the specified value, and the environment variables are save in attribute "environvar" of osimage definition in xCATDB , which will be used to resolve the environment variables used in osimage customized files such as postinstall scripts 