### PR TITLE
fix [FVT]:xcat-inventory export osimage could not find correct file #47

### DIFF
--- a/xcat-inventory/xcclient/inventory/vutil.py
+++ b/xcat-inventory/xcclient/inventory/vutil.py
@@ -72,7 +72,7 @@ def underpath(filename,path):
 def getfileanddeplist(infilelist):
     #helper function to return a dict whose keys are file "filename" specified and files included by it 
     def getincfiledict(filename,filedict={}):
-        regex_include=r'^#INCLUDE:([^#]+)#$'
+        regex_include=r'^#INCLUDE:\s*([^#]+)#$'
         if filename in filedict.keys():
             return
         filedict[filename]=1
@@ -85,7 +85,7 @@ def getfileanddeplist(infilelist):
             for line in filelines:
                 matchobj_include=re.search(regex_include,line.strip()) 
                 if matchobj_include:
-                    incfile=matchobj_include.group(1)
+                    incfile=matchobj_include.group(1).strip()
                     incfile=os.path.realpath(incfile)
                     if incfile not in filedict.keys():
                         getincfiledict(incfile,filedict)


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-inventory/issues/47:

UT:
```
[root@boston02 xcclient]# xcat-inventory export -t osimage -o test_osimage -d /tmp/imagedata/export
The osimage objects has been exported to directory /tmp/imagedata/export
[root@boston02 xcclient]#
```

