### PR TITLE
remove the default value for variable SWDIR

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -339,8 +339,6 @@ def importfromfile(objtypelist, objlist, location,dryrun=None,version=None,updat
   
     if 'SWDIR' in os.environ.keys():
         varswdir=os.environ['SWDIR']
-    else:
-        varswdir="/install/REPO" 
 
     if varswdir is not None:
         vardict['SWDIR']=varswdir


### PR DESCRIPTION
remove the default value of variable `SWDIR `

```
[root@c910f03c05k21 xCAT-Incubator]# xcat-inventory import -f /home/yangsbj/xcat_clusters/osimage/rhels/ist.redhat.perf.custom.netboot.DL.osimage.yaml
unresolved variables in "/home/yangsbj/xcat_clusters/osimage/rhels/ist.redhat.perf.custom.netboot.DL.osimage.yaml": "SWDIR", please export them in environment variables
```