### PR TITLE
* remove the default value for variable SWDIR

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -328,7 +328,7 @@ def importfromfile(objtypelist, objlist, location,dryrun=None,version=None,updat
         vargitrepo=os.environ['GITREPO']
     else:
         oldcwd=os.getcwd()
-        os.chdir(os.path.dirname(location))
+        os.chdir(os.path.dirname(os.path.realpath(location)))
         (retcode,out,err)=runCommand("git rev-parse --show-toplevel")
         if retcode==0:
             vargitrepo=out.strip()
@@ -359,7 +359,7 @@ def importfromfile(objtypelist, objlist, location,dryrun=None,version=None,updat
         try: 
             obj_attr_dict = yaml.load(contents)
         except Exception,e:
-            raise InvalidFileException("Error: failed to load file "+location+": "+str(e))
+            raise InvalidFileException("Error: failed to load file \"%s\", please validate the file with 'yamllint %s'(for yaml format) or 'cat %s|python -mjson.tool'(for json format)!"%(location,location,location))
   
     versinfile=None
     if 'schema_version' in obj_attr_dict.keys():


### PR DESCRIPTION
* fix a issue to use relative path for -f without prefix directory

UT:

before fix:
```
[root@c910f03c05k21 xCAT-Incubator]# xcat-inventory import -f README.md
Traceback (most recent call last):
  File "/opt/xcat/lib/python/xcclient/inventory/shell.py", line 62, in main
    InventoryShell('xcat-inventory','0.1.4 (git commit 2ac4ede95e6a8509a7236a418c8c310c9ad30289)').run(sys.argv[1:], '1.0', "xCAT inventory management tool")
  File "/opt/xcat/lib/python/xcclient/shell.py", line 193, in run
    return args.func(args)
  File "/opt/xcat/lib/python/xcclient/inventory/shell.py", line 45, in do_import
    mgr.importobj(args.path,args.directory,args.type,args.name,dryrun=args.dryrun,version=args.version,update=args.update)
  File "/opt/xcat/lib/python/xcclient/inventory/manager.py", line 476, in importobj
    importfromfile(objtypelist, objnamelist,srcfile,dryrun,version,update)
  File "/opt/xcat/lib/python/xcclient/inventory/manager.py", line 331, in importfromfile
    os.chdir(os.path.dirname(location))
OSError: [Errno 2] No such file or directory: ''
```
after fix:
```
[root@c910f03c05k21 xCAT-Incubator]# xcat-inventory import -f README.md
Error: failed to load file "README.md", please validate the file with 'yamllint README.md'(for yaml format) or 'cat README.md|python -mjson.tool'(for json format)!
```
