### PR TITLE
support osimage export with environvars

### DIFF
--- a/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
@@ -20,13 +20,19 @@
     - "C:${{value=V{provision_mode}: True if str(value) in ('install','netboot','statelite') else False}}"
     package_selection:
       pkglist: 
-      - "T{linuximage.pkglist}"
+      - "${{value=T{linuximage.pkglist},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "W:T{linuximage.pkglist}=${{value=V{package_selection.pkglist}: ','.join(value) if type(value) == type([]) else value}}"
       - "F:${{flist=V{package_selection.pkglist}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
-      pkgdir: "T{linuximage.pkgdir}"
+      pkgdir: 
+      - "${{value=T{linuximage.pkgdir},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "W:T{linuximage.pkgdir}=${{value=V{package_selection.pkgdir}: ','.join(value) if type(value) == type([]) else value}}"
       otherpkglist: 
-      - "T{linuximage.otherpkglist}"
+      - "${{value=T{linuximage.otherpkglist},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "W:T{linuximage.otherpkglist}=${{value=V{package_selection.otherpkglist}: ','.join(value) if type(value) == type([]) else value}}"
       - "F:${{flist=V{package_selection.otherpkglist}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
-      otherpkgdir: "T{linuximage.otherpkgdir}"
+      otherpkgdir: 
+      - "${{value=T{linuximage.otherpkgdir},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "W:T{linuximage.otherpkgdir}=${{value=V{package_selection.otherpkgdir}: ','.join(value) if type(value) == type([]) else value}}"
     osupdatename: "T{osimage.osupdatename}"
     kernel_driver:
       driverupdatesrc: "T{linuximage.driverupdatesrc}"
@@ -35,10 +41,14 @@
       kernelver: "T{linuximage.kernelver}"
     scripts:
       postscripts: 
-      - "T{osimage.postscripts}"
+      - "${{value=T{osimage.postscripts},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "W:T{osimage.postscripts}=${{value=V{scripts.postscripts}: ','.join(value) if type(value) == type([]) else value}}"
       postbootscripts: 
-      - "T{osimage.postbootscripts}"
-    environvars: "T{osimage.environvar}"
+      - "${{value=T{osimage.postbootscripts},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "W:T{osimage.postbootscripts}=${{value=V{scripts.postbootscripts}: ','.join(value) if type(value) == type([]) else value}}"
+    environvars: 
+      - "${{:''}}"
+      - "W:T{osimage.environvar}=${{:V{environvars}}}"
     kernel_dump:
       dump: "T{linuximage.dump}"
       crashkernelsize: "T{linuximage.crashkernelsize}"
@@ -50,16 +60,19 @@
     - "${{imagetype=V{imagetype} :T{linuximage.partitionfile} if imagetype == 'linux' else T{winimage.partitionfile} if imagetype == 'windows' else None}}"
     - "F:${{flist=V{diskpartitionspec}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
     filestosync: 
-    - "T{osimage.synclists}"
+    - "${{value=T{osimage.synclists},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+    - "W:T{osimage.synclists}=${{value=V{filestosync}: ','.join(value) if type(value) == type([]) else value}}"
     - "F:${{flist=V{filestosync}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
     addkcmdline: "T{linuximage.addkcmdline}"
     boottarget: "T{linuximage.boottarget}"                                 
     genimgoptions:
       exlist: 
-      - "T{linuximage.exlist}"
+      - "${{value=T{linuximage.exlist},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "W:T{linuximage.exlist}=${{value=V{genimgoptions.exlist}: ','.join(value) if type(value) == type([]) else value}}"
       - "F:${{flist=V{genimgoptions.exlist}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       postinstall: 
-      - "T{linuximage.postinstall}"
+      - "${{value=T{linuximage.postinstall},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "W:T{linuximage.postinstall}=${{value=V{genimgoptions.postinstall}: ','.join(value) if type(value) == type([]) else value}}"
       - "F:${{flist=V{genimgoptions.postinstall}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       rootimgdir: "T{linuximage.rootimgdir}"
       nodebootif: "T{linuximage.nodebootif}"

--- a/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
@@ -20,18 +20,18 @@
     - "C:${{value=V{provision_mode}: True if str(value) in ('install','netboot','statelite') else False}}"
     package_selection:
       pkglist: 
-      - "${{value=T{linuximage.pkglist},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "${{value=T{linuximage.pkglist},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{linuximage.pkglist}=${{value=V{package_selection.pkglist}: ','.join(value) if type(value) == type([]) else value}}"
       - "F:${{flist=V{package_selection.pkglist}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
       pkgdir: 
-      - "${{value=T{linuximage.pkgdir},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "${{value=T{linuximage.pkgdir},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{linuximage.pkgdir}=${{value=V{package_selection.pkgdir}: ','.join(value) if type(value) == type([]) else value}}"
       otherpkglist: 
-      - "${{value=T{linuximage.otherpkglist},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "${{value=T{linuximage.otherpkglist},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{linuximage.otherpkglist}=${{value=V{package_selection.otherpkglist}: ','.join(value) if type(value) == type([]) else value}}"
       - "F:${{flist=V{package_selection.otherpkglist}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       otherpkgdir: 
-      - "${{value=T{linuximage.otherpkgdir},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "${{value=T{linuximage.otherpkgdir},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{linuximage.otherpkgdir}=${{value=V{package_selection.otherpkgdir}: ','.join(value) if type(value) == type([]) else value}}"
     osupdatename: "T{osimage.osupdatename}"
     kernel_driver:
@@ -41,14 +41,14 @@
       kernelver: "T{linuximage.kernelver}"
     scripts:
       postscripts: 
-      - "${{value=T{osimage.postscripts},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "${{value=T{osimage.postscripts},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{osimage.postscripts}=${{value=V{scripts.postscripts}: ','.join(value) if type(value) == type([]) else value}}"
       postbootscripts: 
-      - "${{value=T{osimage.postbootscripts},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "${{value=T{osimage.postbootscripts},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{osimage.postbootscripts}=${{value=V{scripts.postbootscripts}: ','.join(value) if type(value) == type([]) else value}}"
     environvars: 
       - "${{:''}}"
-      - "W:T{osimage.environvar}=${{:V{environvars}}}"
+      - "W:T{osimage.environvar}=${{:V{environvars} if V{environvars} else None }}"
     kernel_dump:
       dump: "T{linuximage.dump}"
       crashkernelsize: "T{linuximage.crashkernelsize}"
@@ -57,21 +57,23 @@
     - "F:${{flist=V{template}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
       
     diskpartitionspec: 
-    - "${{imagetype=V{imagetype} :T{linuximage.partitionfile} if imagetype == 'linux' else T{winimage.partitionfile} if imagetype == 'windows' else None}}"
+    - "${{imagetype=V{imagetype}, envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {}: vutil.strsubst(T{linuximage.partitionfile},envars) if imagetype == 'linux' else vutil.strsubst(T{winimage.partitionfile},envars) if imagetype == 'windows' else None}}"
+    - "W:T{linuximage.partitionfile}=${{imagetype=V{imagetype}: V{diskpartitionspec} if imagetype == 'linux' else None }}"
+    - "W:T{winimage.partitionfile}=${{imagetype=V{imagetype}: V{diskpartitionspec} if imagetype == 'windows' else None }}"
     - "F:${{flist=V{diskpartitionspec}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
     filestosync: 
-    - "${{value=T{osimage.synclists},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+    - "${{value=T{osimage.synclists},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None}} "
     - "W:T{osimage.synclists}=${{value=V{filestosync}: ','.join(value) if type(value) == type([]) else value}}"
     - "F:${{flist=V{filestosync}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
     addkcmdline: "T{linuximage.addkcmdline}"
     boottarget: "T{linuximage.boottarget}"                                 
     genimgoptions:
       exlist: 
-      - "${{value=T{linuximage.exlist},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "${{value=T{linuximage.exlist},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{linuximage.exlist}=${{value=V{genimgoptions.exlist}: ','.join(value) if type(value) == type([]) else value}}"
       - "F:${{flist=V{genimgoptions.exlist}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       postinstall: 
-      - "${{value=T{linuximage.postinstall},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] }} "
+      - "${{value=T{linuximage.postinstall},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{linuximage.postinstall}=${{value=V{genimgoptions.postinstall}: ','.join(value) if type(value) == type([]) else value}}"
       - "F:${{flist=V{genimgoptions.postinstall}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       rootimgdir: "T{linuximage.rootimgdir}"

--- a/xcat-inventory/xcclient/inventory/vutil.py
+++ b/xcat-inventory/xcclient/inventory/vutil.py
@@ -97,6 +97,11 @@ def getfileanddeplist(infilelist):
         getincfiledict(filename,filedict)
     return filedict.keys()
 
+def strsubst(string,subdict={}):
+    for k in subdict.keys():
+        string=string.replace(k,subdict[k])
+    return string
+
 if __name__ == "__main__":
     pass
     

--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -186,17 +186,21 @@ class XcatBase(object):
         mydepvallist=self._depdict_tab[tabcol]['depvallist']
         myexpression=self._depdict_tab[tabcol]['expression']
         myschmpath=self._depdict_tab[tabcol]['schmpath']
+        ctxdict={}
         for item in mydepvallist:
             myval=Util_getdictval(self._mydict,item)
             if myval is None:
                 myval=''
-            myexpression=myexpression.replace('V{'+item+'}',"'"+str(myval).replace("'","\\'")+"'")
+            newitem=item.replace('.','_').replace('{','_').replace('}','_')
+            newitem="V_%s"%(newitem)
+            ctxdict[newitem]=myval
+            myexpression=myexpression.replace('V{'+item+'}',newitem)
         for item in mydeptablist:
             tabval=''
             if item in self._dbhash.keys():
                 tabval=self._dbhash[item]
             else:
-                tabvol=self.__evalschema_tab(item) 
+                tabval=self.__evalschema_tab(item) 
             myexpression=myexpression.replace('T{'+item+'}',"'"+str(tabval).replace("'","\\'")+"'")   
         tabmatched=re.findall(r'T\{(\S+)\}',myexpression)
         if tabmatched:
@@ -204,9 +208,9 @@ class XcatBase(object):
                 if myschmpath: 
                     myexpression=myexpression.replace('T{'+item+'}',"'"+str(item).replace("'","\\'")+"'")
                 else:
-                    tabvol=self.__evalschema_tab(item)
+                    tabval=self.__evalschema_tab(item)
                     myexpression=myexpression.replace('T{'+item+'}',"'"+str(tabval).replace("'","\\'")+"'")
-        evalexp=eval("lambda "+myexpression)
+        evalexp=eval("lambda "+myexpression,ctxdict)
         result=evalexp()
         if myschmpath:
             if 0==cmp(result,tabcol):


### PR DESCRIPTION
with this feature, the substring in `otherpkgdir`, `otherpkglist`, `pkgdir`,  `pkglist` , `postinstall` 
`environvar`,`synclists`,`rootimgdir `,`partitionfile`,`template` attributes are replaced with the environment variables in `environvar`

UT:
```
[root@c910f03c05k21 xCAT-Incubator]# lsdef -t osimage -o ist.redhat.perf.custom.netboot.DL
Object name: ist.redhat.perf.custom.netboot.DL
    environvar=GITREPO=/tmp,SWDIR=/install/swrepo
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.5-ppc64le
    osname=Linux
    osvers=rhels7.5
    otherpkgdir=/install/swrepo/software
    otherpkglist=/tmp/osimage/rhels/common/otherpkglist/essl.otherpkglist,/tmp/osimage/rhels/common/otherpkglist/pessl.otherpkglist,/tmp/osimage/rhels/common/otherpkglist/xlc.otherpkglist,/tmp/osimage/rhels/common/otherpkglist/xlf.otherpkglist,/tmp/osimage/rhels/common/otherpkglist/PPT.otherpkglist,/tmp/osimage/rhels/common/otherpkglist/SMPI.otherpkglist,/tmp/osimage/rhels/common/otherpkglist/cuda.otherpkglist
    permission=755
    pkgdir=/install/swrepo/os/rhels/rhels7.5-ga/ppc64le,/install/swrepo/software/nvidia/cuda-dep/repo/ppc64le/
    pkglist=/tmp/osimage/rhels/common/pkglist/all.pkglist,/tmp/osimage/rhels/common/pkglist/cuda.pkglist,/tmp/osimage/rhels/common/pkglist/ib.pkglist
    postinstall=/tmp/osimage/rhels/common/postinstall/MOFED.postinstall,/tmp/osimage/rhels/common/postinstall/CSM.postinstall,/tmp/osimage/rhels/common/postinstall/compute.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/custom/ist.perf.custom.netboot.DL
    synclists=/tmp/osimage/rhels/syncfiles/synclist
    usercomment=rhels7.5,ist,cuda-396.27,mofed-3-2.2.2.5
[root@c910f03c05k21 xCAT-Incubator]# xcat-inventory export -t osimage -o ist.redhat.perf.custom.netboot.DL --format=yaml
osimage:
  ist.redhat.perf.custom.netboot.DL:
    basic_attributes:
      arch: ppc64le
      distribution: rhels7.5
      osdistro: rhels7.5-ppc64le
      osname: Linux
    deprecated:
      comments: rhels7.5,ist,cuda-396.27,mofed-3-2.2.2.5
    filestosync:
    - '{{GITREPO}}/osimage/rhels/syncfiles/synclist'
    genimgoptions:
      permission: '755'
      postinstall:
      - '{{GITREPO}}/osimage/rhels/common/postinstall/MOFED.postinstall'
      - '{{GITREPO}}/osimage/rhels/common/postinstall/CSM.postinstall'
      - '{{GITREPO}}/osimage/rhels/common/postinstall/compute.postinstall'
      rootimgdir: /install/custom/ist.perf.custom.netboot.DL
    imagetype: linux
    package_selection:
      otherpkgdir:
      - '{{SWDIR}}/software'
      otherpkglist:
      - '{{GITREPO}}/osimage/rhels/common/otherpkglist/essl.otherpkglist'
      - '{{GITREPO}}/osimage/rhels/common/otherpkglist/pessl.otherpkglist'
      - '{{GITREPO}}/osimage/rhels/common/otherpkglist/xlc.otherpkglist'
      - '{{GITREPO}}/osimage/rhels/common/otherpkglist/xlf.otherpkglist'
      - '{{GITREPO}}/osimage/rhels/common/otherpkglist/PPT.otherpkglist'
      - '{{GITREPO}}/osimage/rhels/common/otherpkglist/SMPI.otherpkglist'
      - '{{GITREPO}}/osimage/rhels/common/otherpkglist/cuda.otherpkglist'
      pkgdir:
      - '{{SWDIR}}/os/rhels/rhels7.5-ga/ppc64le'
      - '{{SWDIR}}/software/nvidia/cuda-dep/repo/ppc64le/'
      pkglist:
      - '{{GITREPO}}/osimage/rhels/common/pkglist/all.pkglist'
      - '{{GITREPO}}/osimage/rhels/common/pkglist/cuda.pkglist'
      - '{{GITREPO}}/osimage/rhels/common/pkglist/ib.pkglist'
    provision_mode: netboot
    role: compute
schema_version: '1.0'

#Version 2.14.1 (git commit 2f87973517231a694fe813f75338ab47da0a9575, built Mon May 28 04:29:58 EDT 2018)

```