### PR TITLE
fix issue [FVT]xcat-inventory import could not save files when the files are included in osimage defintion. #52

### DIFF
--- a/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
@@ -22,14 +22,14 @@
       pkglist: 
       - "${{value=T{linuximage.pkglist},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{linuximage.pkglist}=${{value=V{package_selection.pkglist}: ','.join(value) if type(value) == type([]) else value}}"
-      - "F:${{flist=V{package_selection.pkglist}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
+      - "F:${{flist=V{package_selection.pkglist}: [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
       pkgdir: 
       - "${{value=T{linuximage.pkgdir},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{linuximage.pkgdir}=${{value=V{package_selection.pkgdir}: ','.join(value) if type(value) == type([]) else value}}"
       otherpkglist: 
       - "${{value=T{linuximage.otherpkglist},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{linuximage.otherpkglist}=${{value=V{package_selection.otherpkglist}: ','.join(value) if type(value) == type([]) else value}}"
-      - "F:${{flist=V{package_selection.otherpkglist}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
+      - "F:${{flist=V{package_selection.otherpkglist}: [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       otherpkgdir: 
       - "${{value=T{linuximage.otherpkgdir},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{linuximage.otherpkgdir}=${{value=V{package_selection.otherpkgdir}: ','.join(value) if type(value) == type([]) else value}}"
@@ -64,18 +64,18 @@
     filestosync: 
     - "${{value=T{osimage.synclists},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None}} "
     - "W:T{osimage.synclists}=${{value=V{filestosync}: ','.join(value) if type(value) == type([]) else value}}"
-    - "F:${{flist=V{filestosync}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
+    - "F:${{flist=V{filestosync}: [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/') ] }}"
     addkcmdline: "T{linuximage.addkcmdline}"
     boottarget: "T{linuximage.boottarget}"                                 
     genimgoptions:
       exlist: 
       - "${{value=T{linuximage.exlist},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{linuximage.exlist}=${{value=V{genimgoptions.exlist}: ','.join(value) if type(value) == type([]) else value}}"
-      - "F:${{flist=V{genimgoptions.exlist}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
+      - "F:${{flist=V{genimgoptions.exlist}: [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       postinstall: 
       - "${{value=T{linuximage.postinstall},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{linuximage.postinstall}=${{value=V{genimgoptions.postinstall}: ','.join(value) if type(value) == type([]) else value}}"
-      - "F:${{flist=V{genimgoptions.postinstall}.split(','): [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
+      - "F:${{flist=V{genimgoptions.postinstall}: [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
       rootimgdir: "T{linuximage.rootimgdir}"
       nodebootif: "T{linuximage.nodebootif}"
       permission: "T{linuximage.permission}"


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-inventory/issues/52:
UT:
```
[root@boston02 xcat-inventory]# xcattest -t export_import_osimage_with_INCLUDE_in_file
xCAT automated test started at Thu Jun 28 05:02:46 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Warning: No compute node defined, can't get ARCH of compute node
Warning: No compute node defined, can't get HCP TYPE of compute node
******************************
loading test cases
******************************
To run:
export_import_osimage_with_INCLUDE_in_file
******************************
Start to run test cases
******************************
------START::export_import_osimage_with_INCLUDE_in_file::Time:Thu Jun 28 05:02:46 2018------

RUN:dir="/tmp/imagedata/";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir [Thu Jun 28 05:02:46 2018]
mv: cannot move ‘/tmp/imagedata/’ to a subdirectory of itself, ‘/tmp/imagedata/.bak’
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:dir="/tmp/imagedata/export";if [ -e "${dir}" ];then mv ${dir} ${dir}".bak"; fi; mkdir -p $dir [Thu Jun 28 05:02:46 2018]
mv: cannot move ‘/tmp/imagedata/export’ to ‘/tmp/imagedata/export.bak/export’: Directory not empty
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:cp -rf /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/imagedata/test_osimage /tmp/imagedata [Thu Jun 28 05:02:46 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
CHECK:rc == 0	[Pass]

RUN:lsdef -t osimage -o test_osimage >/dev/null 2>&1;if [[ $? -eq 0 ]]; then lsdef -t osimage -o test_osimage -z >/tmp/imagedata/test_osimage.org.stanza ;rmdef -t osimage -o test_osimage;fi [Thu Jun 28 05:02:46 2018]
ElapsedTime:2 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been removed.
CHECK:rc == 0	[Pass]

RUN:cat /tmp/imagedata/test_osimage/test_osimage.stanza |mkdef -z [Thu Jun 28 05:02:48 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
1 object definitions have been created or modified.
CHECK:rc == 0	[Pass]

RUN:rm -rf /tmp/imagedata/test_osimage/test_osimage.stanza [Thu Jun 28 05:02:48 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:lsdef -t osimage -o test_osimage [Thu Jun 28 05:02:48 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Object name: test_osimage
    exlist=/tmp/imagedata/test_osimage/exlist
    imagetype=linux
    otherpkglist=/tmp/imagedata/test_osimage/otherpkglist
    partitionfile=/tmp/imagedata/test_osimage/partitionfile
    pkglist=/tmp/imagedata/test_osimage/pkglist
    postinstall=/tmp/imagedata/test_osimage/postinstall
    provmethod=install
    synclists=/tmp/imagedata/test_osimage/synclists
    template=/tmp/imagedata/test_osimage/template.tmpl
CHECK:rc == 0	[Pass]

RUN:xcat-inventory export -t osimage -o test_osimage -d /tmp/imagedata/export [Thu Jun 28 05:02:49 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
The osimage objects has been exported to directory /tmp/imagedata/export
CHECK:output =~ The osimage objects has been exported to directory /tmp/imagedata/export	[Pass]

RUN:ls -lFR /tmp/imagedata/export [Thu Jun 28 05:02:50 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
/tmp/imagedata/export:
total 4
drwxr-xr-x 4 root root 4096 Jun 28 05:02 test_osimage/

/tmp/imagedata/export/test_osimage:
total 12
-rw-r--r-- 1 root root 1053 Jun 28 05:02 definition.json
drwxr-xr-x 2 root root 4096 Jun 28 05:02 etc/
drwxr-xr-x 3 root root 4096 Jun 28 05:02 tmp/

/tmp/imagedata/export/test_osimage/etc:
total 4
-rw-r--r-- 1 root root 871 Jun 28 05:02 hosts

/tmp/imagedata/export/test_osimage/tmp:
total 4
drwxr-xr-x 3 root root 4096 Jun 28 05:02 imagedata/

/tmp/imagedata/export/test_osimage/tmp/imagedata:
total 4
drwxr-xr-x 2 root root 4096 Jun 28 05:02 test_osimage/

/tmp/imagedata/export/test_osimage/tmp/imagedata/test_osimage:
total 76
-rw-r--r-- 1 root root  70 Jun 28 05:02 exlist
-rw-r--r-- 1 root root  33 Jun 28 05:02 file1.1
-rw-r--r-- 1 root root  46 Jun 28 05:02 file2.1
-rw-r--r-- 1 root root  46 Jun 28 05:02 file2.2
-rw-r--r-- 1 root root  46 Jun 28 05:02 file2.3
-rw-r--r-- 1 root root  92 Jun 28 05:02 file3.1
-rw-r--r-- 1 root root  92 Jun 28 05:02 file3.2
-rw-r--r-- 1 root root  50 Jun 28 05:02 file3.3
-rw-r--r-- 1 root root  82 Jun 28 05:02 file4.1
-rw-r--r-- 1 root root  82 Jun 28 05:02 file4.2
-rw-r--r-- 1 root root  82 Jun 28 05:02 file4.3
-rw-r--r-- 1 root root  57 Jun 28 05:02 file5
-rw-r--r-- 1 root root  40 Jun 28 05:02 file6
-rw-r--r-- 1 root root 169 Jun 28 05:02 otherpkglist
-rw-r--r-- 1 root root  75 Jun 28 05:02 partitionfile
-rw-r--r-- 1 root root  75 Jun 28 05:02 pkglist
-rw-r--r-- 1 root root  73 Jun 28 05:02 postinstall
-rw-r--r-- 1 root root  44 Jun 28 05:02 synclists
-rw-r--r-- 1 root root 134 Jun 28 05:02 template.tmpl

RUN:diff -r /tmp/imagedata/test_osimage /tmp/imagedata/export/test_osimage/tmp/imagedata/test_osimage/ [Thu Jun 28 05:02:50 2018]
ElapsedTime:0 sec
RETURN rc = 1
OUTPUT:
Only in /tmp/imagedata/test_osimage: file7
CHECK:output =~ Only in /tmp/imagedata/test_osimage: file7	[Pass]

RUN:diff -y /etc/hosts /tmp/imagedata/export/test_osimage/etc/hosts [Thu Jun 28 05:02:50 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
127.0.0.1   localhost localhost.localdomain localhost4 localh	127.0.0.1   localhost localhost.localdomain localhost4 localh
::1         localhost localhost.localdomain localhost6 localh	::1         localhost localhost.localdomain localhost6 localh

172.20.253.31 boston02 boston02.pok.stglabs.ibm.com		172.20.253.31 boston02 boston02.pok.stglabs.ibm.com
10.5.23.1 mgmtsw01 mgmtsw01.pok.stglabs.ibm.com 		10.5.23.1 mgmtsw01 mgmtsw01.pok.stglabs.ibm.com
172.21.208.100 mid08 mid08.pok.stglabs.ibm.com 			172.21.208.100 mid08 mid08.pok.stglabs.ibm.com
172.21.253.104 f6pdu15 f6pdu15.pok.stglabs.ibm.com 		172.21.253.104 f6pdu15 f6pdu15.pok.stglabs.ibm.com
172.21.253.105 f6pdu16 f6pdu16.pok.stglabs.ibm.com 		172.21.253.105 f6pdu16 f6pdu16.pok.stglabs.ibm.com
10.6.25.1 core01 core01.pok.stglabs.ibm.com 			10.6.25.1 core01 core01.pok.stglabs.ibm.com
172.20.254.2 sn02 sn02.pok.stglabs.ibm.com 			172.20.254.2 sn02 sn02.pok.stglabs.ibm.com
9.114.82.90 coral-pdu coral-pdu.pok.stglabs.ibm.com 		9.114.82.90 coral-pdu coral-pdu.pok.stglabs.ibm.com
172.21.208.03 mid08tor03 mid08tor03.pok.stglabs.ibm.com 	172.21.208.03 mid08tor03 mid08tor03.pok.stglabs.ibm.com
172.20.226.10 mid08tor03cn10 mid08tor03cn10.pok.stglabs.ibm.c	172.20.226.10 mid08tor03cn10 mid08tor03cn10.pok.stglabs.ibm.c
172.20.226.1 mid08tor03cn01 mid08tor03cn01.pok.stglabs.ibm.co	172.20.226.1 mid08tor03cn01 mid08tor03cn01.pok.stglabs.ibm.co
172.21.254.2 sn02-enP5p1s0f0 sn02-enP5p1s0f0.pok.stglabs.ibm.	172.21.254.2 sn02-enP5p1s0f0 sn02-enP5p1s0f0.pok.stglabs.ibm.
172.20.226.26 mid08tor03cn26 mid08tor03cn26.pok.stglabs.ibm.c	172.20.226.26 mid08tor03cn26 mid08tor03cn26.pok.stglabs.ibm.c
CHECK:rc == 0	[Pass]

------END::export_import_osimage_with_INCLUDE_in_file::Passed::Time:Thu Jun 28 05:02:50 2018 ::Duration::4 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Thu Jun 28 05:02:50 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20180628050246 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20180628050246 file for time consumption
```