### PR TITLE
fix issue [FVT]:xcat-inventory import could not import all osimages when there is files under the import directory #59

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -474,8 +474,10 @@ def importobjdir(location,dryrun=None,version=None,update=True,dbsession=None):
     print("The object "+objname+" has been imported")
 
 def importfromdir(location,objtype='osimage',objnamelist=None,dryrun=None,version=None,update=True,dbsession=None):
+    importall=0
     if not objnamelist:
-        objnamelist=os.listdir(location)
+        objnamelist = [filename for filename in os.listdir(location) if os.path.isdir(os.path.join(location,filename))]
+        importall=1
     if update==False:
         if dbsession is None:
             dbsession=DBsession()
@@ -485,7 +487,13 @@ def importfromdir(location,objtype='osimage',objnamelist=None,dryrun=None,versio
     for objname in objnamelist:
         if os.path.exists(os.path.join(location,objname)):
             objdir=os.path.join(location,objname)
-            importobjdir(objdir,dryrun,version,update,dbsession)
+            if importall:
+                try:
+                    importobjdir(objdir,dryrun,version,update,dbsession)
+                except Exception,e:
+                    print("processing osimage directory %s: %s"%(objdir,str(e)),file=sys.stderr)
+            else:
+                importobjdir(objdir,dryrun,version,update,dbsession)
         else:
             print("the specified object \""+objname+"\" does not exist under \""+location+"\"!",file=sys.stderr)
     if dbsession:


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-inventory/issues/59:
UT:
```
[root@boston02 inventory]# xcat-inventory import -t osimage -d /tmp/export
Importing object: test_osimage
Inventory import successfully!
Warning: the /tmp/imagedata/test_osimage/file4.2 already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/file4.1 already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/file4.3 already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/pkglist already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/exlist already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/file1.1 already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/file6 already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/synclists already exists, will be overwritten
Warning: the /etc/hosts already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/file5 already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/postinstall already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/file2.3 already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/file2.2 already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/file2.1 already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/otherpkglist already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/template.tmpl already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/file3.1 already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/file3.2 already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/file3.3 already exists, will be overwritten
Warning: the /tmp/imagedata/test_osimage/partitionfile already exists, will be overwritten
The object test_osimage has been imported
Importing object: test_myimage1
Inventory import successfully!
The object test_myimage1 has been imported
processing osimage directory /tmp/export/ddd: Error: no definition.json or definition.yaml found under "/tmp/export/ddd"!
Importing object: test_myimage2
Inventory import successfully!
The object test_myimage2 has been imported
```