### PR TITLE
Add -e option for environment variables

### DIFF
--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -39,10 +39,11 @@ class InventoryShell(shell.ClusterShell):
     @shell.arg('-s','--schema-version',dest='version', metavar='<version>', help='schema version of the inventory file. Valid schema versions: '+','.join(mgr.InventoryFactory.getAvailableSchemaVersions())+'. '+'If not specified, the "latest" schema version will be used')
     @shell.arg('--dry', dest='dryrun', action="store_true", default=False, help='Dry run mode, nothing will be commited to xcat database')
     @shell.arg('-c','--clean', dest='update', action="store_false", default=True, help='clean mode. IF specified, all objects other than the ones to import will be removed')
+    @shell.arg('-e','--env', dest='env', metavar='<env_var>', action='append', help='the values of variables in object definitions(only available for osimage object), syntax: "<variable name>=<variable value>" , this option can be used multiple times to specify multiple variables')
     def do_import(self, args):
         """Import inventory file to xcat database"""
         mgr.validate_args(args, 'import')
-        mgr.importobj(args.path,args.directory,args.type,args.name,dryrun=args.dryrun,version=args.version,update=args.update)
+        mgr.importobj(args.path,args.directory,args.type,args.name,dryrun=args.dryrun,version=args.version,update=args.update,envs=args.env)
 
     @shell.arg('-t','--type', metavar='<type>', help='comma "," delimited types of objects to export, valid values: '+','.join(mgr.InventoryFactory.getvalidobjtypes())+'. '+'If not specified, all objects in xcat databse will be exported')
     @shell.arg('-x', '--exclude', dest='exclude', default='', help='types to be excluded when exporting all, delimited with Comma(,).')


### PR DESCRIPTION
UT:
```
RUN:xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json -e GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo -e SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir [Wed Jul 11 03:28:34 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Importing object: test.environments.osimage
Inventory import successfully!
CHECK:output =~ Importing object: test.environments.osimage     [Pass]
CHECK:output =~ Inventory import successfully!  [Pass]
CHECK:rc == 0   [Pass]
```

lsdef:
```
# lsdef -t osimage test.environments.osimage
Object name: test.environments.osimage
    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo,SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.5-ppc64le
    osname=Linux
    osvers=rhels7.5
    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir/otherpkgdir/
    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test1.otherpkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test2.otherpkglist,
    permission=755
    pkgdir=/install/rhels7.5/ppc64le,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir/pkgdir/
    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test1.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test2.pkglist
    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/postinstall/test1.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/custom/test.environments.osimage
    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/syncfiles/synclist
    usercomment=rhels7.5,test_environment_variables
```