### PR TITLE
fix xcat-inventory export failed when some fields in nics table is blank #72

### DIFF
--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -429,6 +429,8 @@ class Node(XcatBase):
                 for key in rawnicsdict.keys():
                     rawvaluelist=rawnicsdict[key].split(',')
                     for nicent in rawvaluelist:
+                        if not nicent:
+                            continue
                         try:
                             (nic,attrstr)=nicent.split('!')
                             if nic not in nicsdict.keys():


### PR DESCRIPTION
fix  https://github.com/xcat2/xcat-inventory/issues/72:

UT:
```
[root@stratton01 ~]# xcat-inventory export -t node -o group1
{
    "node": {
        "group1": {
            "device_type": "server",
            "network_info": {
                "nics": {
                    " eno2": {
                        "networks": [
                            "net-infra"
                        ]
                    },
                    " eno5": {
                        "networks": [
                            "pub-yellow"
                        ],
                        "type": [
                            "ethernet"
                        ]
                    },
                    "eno1": {
                        "hostnamesuffixes": [
                            "-compute"
                        ],
                        "networks": [
                            "xcat-compute"
                        ],
                        "type": [
                            "ethernet"
                        ]
                    },
                    "eno2": {
                        "hostnamesuffixes": [
                            "-net-infra"
                        ]
                    },
                    "eno3": {
                        "hostnamesuffixes": [
                            "-pdu"
                        ],
                        "networks": [
                            "pdu"
                        ],
                        "type": [
                            "ethernet"
                        ]
                    },
                    "eno4": {
                        "hostnamesuffixes": [
                            "-bmc"
                        ],
                        "networks": [
                            "bmc"
                        ],
                        "type": [
                            "ethernet"
                        ]
                    },
                    "eno5": {
                        "hostnamesuffixes": [
                            "-yellow"
                        ]
                    }
                }
            },
            "obj_type": "group",
            "role": "compute"
        }
    },
    "schema_version": "1.0"
}
#Version 2.14.3 (git commit d3f1bbbe2642b720222b7927a81984f1d0190eb3, built Fri Jul 13 06:15:47 EDT 2018)

```