### PR TITLE
support credential export/import

### DIFF
--- a/xcat-inventory/xcclient/inventory/exceptions.py
+++ b/xcat-inventory/xcclient/inventory/exceptions.py
@@ -27,6 +27,8 @@ class BaseException(Exception):
     def __str__(self):
         return self._error_msg
 
+class ObjTypeNonExistException(BaseException):
+    pass
 class ObjNonExistException(BaseException):
     pass
 class CommandException(BaseException):

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -64,7 +64,7 @@ def main():
     except KeyboardInterrupt:
         print("... terminating xCAT inventory management tool", file=sys.stderr)
         sys.exit(2)
-    except (InvalidFileException,ObjNonExistException,CommandException,InvalidValueException,BadDBHdlException,BadSchemaException,DBException,ParseException,InternalException), e:
+    except (InvalidFileException,ObjNonExistException,CommandException,InvalidValueException,BadDBHdlException,BadSchemaException,DBException,ParseException,InternalException,ObjTypeNonExistException), e:
         print(str(e), file=sys.stderr)
         sys.exit(1)
     #except (ParserError), e:

--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -324,7 +324,6 @@ class XcatBase(object):
         schmkey=schemacontent.keys()[0]
         cls._schema=schemacontent[schmkey] 
         cls._schema_loc__=schema
-        #cls.validate_schema_version()
         cls.scanschema()
 
 
@@ -470,8 +469,6 @@ class Node(XcatBase):
                 for key in rawnicsdict.keys():
                     rawvaluelist=rawnicsdict[key].split(',')
                     for nicent in rawvaluelist:
-                        if not nicent:
-                            continue
                         try:
                             (nic,attrstr)=nicent.split('!')
                             if nic not in nicsdict.keys():
@@ -537,5 +534,8 @@ class Site(XcatBase):
 
 class Zone(XcatBase):
     _schema_loc__ = os.path.join(os.path.dirname(__file__), 'schema/latest/zone.yaml')
+
+class Credential(XcatBase):
+    _schema_loc__ = os.path.join(os.path.dirname(__file__), 'schema/latest/credential.yaml')
 if __name__ == "__main__":
     pass


### PR DESCRIPTION
this PR is for feature request https://github.com/xcat2/xcat-inventory/issues/66:
1. add a new object type `credential`
2. the credential object contain the xcatd SSL CA certificate, private key, root's client SSL credential and server side SSL certificate
```
[root@c910f03c05k21 inventory]# xcat-inventory export -t credential
{
    "credential": {
        "credential": {
            "CA": {
                "certificate": "/etc/xcat/ca/ca-cert.pem",
                "private_key": "/etc/xcat/ca/private/ca-key.pem"
            },
            "client": {
                "root": "/root/.xcat/client-cred.pem"
            },
            "server": "/etc/xcat/cert/server-cred.pem"
        }
    },
    "schema_version": "1.0"
}
#Version 2.14.3 (git commit d74f1eed53ef385d80a9013d46c2a7cff1de06e4, built Wed Jul 18 06:15:52 EDT 2018)

```
3. `xcat-inventory export -d` can be used to export the definition file and the credential files to destination directory
4. `xcat-inventory import -d` is used to import the credential files to the correct place 


UT:

export:
```
[root@c910f03c05k21 inventory]# xcat-inventory export -t credential -d /tmp/credential/
The credential objects has been exported to directory /tmp/credential/
[root@c910f03c05k21 inventory]# tree -a /tmp/credential/
/tmp/credential/
└── credential
    ├── definition.json
    ├── etc
    │   └── xcat
    │       ├── ca
    │       │   ├── ca-cert.pem
    │       │   └── private
    │       │       └── ca-key.pem
    │       └── cert
    │           └── server-cred.pem
    └── root
        └── .xcat
            └── client-key.pem

8 directories, 5 files
```

import:
```
[root@c910f03c05k21 inventory]# xcat-inventory import  -d /tmp/credential/
Inventory import successfully!
Warning: the /etc/xcat/ca/ca-cert.pem already exists, will be overwritten
Warning: the /etc/xcat/ca/private/ca-key.pem already exists, will be overwritten
Warning: the /root/.xcat/client-key.pem already exists, will be overwritten
Warning: the /etc/xcat/cert/server-cred.pem already exists, will be overwritten
The object credential has been imported
```