### PR TITLE
Support list in YAML for user comments for osimage object

### DIFF
--- a/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
@@ -113,5 +113,7 @@
       isdeletable: "T{osimage.isdeletable}"
       nimimagetmp: "T{nimimage.tmp}"
       otherifce: "T{linuximage.otherifce}"
-      comments: "T{linuximage.comments}"
+      comments: 
+      - "${{value=T{linuximage.comments}: value.split(',') if value else None}}"
+      - "W:T{linuximage.comments}=${{value=V{deprecated.comments}: ','.join(value) if type(value)==list else value }}"
       krpmver: "T{linuximage.krpmver}"


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-inventory/issues/80:

UT:
for osimage definition:
```
[root@c910f03c05k21 1.0]# lsdef -t osimage -o ist.redhat-alt.perf.custom.install.DF
Object name: ist.redhat-alt.perf.custom.install.DF
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.5-alternate-ppc64le
    osname=Linux
    osvers=rhels7.5-alternate
    otherpkgdir=/install/REPO/software
    otherpkglist=/install/xcat_clusters/osimage/rhels/common/otherpkglist/essl.otherpkglist,/install/xcat_clusters/osimage/rhels/common/otherpkglist/pessl.otherpkglist,/install/xcat_clusters/osimage/rhels/common/otherpkglist/xlc.otherpkglist,/install/xcat_clusters/osimage/rhels/common/otherpkglist/xlf.otherpkglist,/install/xcat_clusters/osimage/rhels/common/otherpkglist/PPT.otherpkglist,/install/xcat_clusters/osimage/rhels/common/otherpkglist/SMPI.otherpkglist,/install/xcat_clusters/osimage/rhels/common/otherpkglist/cuda.otherpkglist
    pkgdir=/install/REPO/os/rhels/rhels7.5-alt-ga/ppc64le,/install/REPO/software/nvidia/cuda-dep/repo/ppc64le/
    pkglist=/install/xcat_clusters/osimage/rhels/common/pkglist/all.df.pkglist
    postbootscripts=/install/postscripts/custom_postscripts/mountEMS_install.sh,/install/postscripts/custom_postscripts/syncfilesfromEMS.sh
    profile=compute
    provmethod=install
    usercomment=rhels7.5,ist,cuda-9.2.88-396.29
```

export the osimage:
```
[root@c910f03c05k21 1.0]# xcat-inventory export -t osimage -o ist.redhat-alt.perf.custom.install.DF --format=yaml -f /tmp/ist.redhat-alt.perf.custom.install.DF.yaml
The inventory data has been dumped to /tmp/ist.redhat-alt.perf.custom.install.DF.yaml

[root@c910f03c05k21 1.0]# cat /tmp/ist.redhat-alt.perf.custom.install.DF.yaml
osimage:
  ist.redhat-alt.perf.custom.install.DF:
    basic_attributes:
      arch: ppc64le
      distribution: rhels7.5-alternate
      osdistro: rhels7.5-alternate-ppc64le
      osname: Linux
    deprecated:
      comments:
      - rhels7.5
      - ist
      - cuda-9.2.88-396.29
    imagetype: linux
    package_selection:
      otherpkgdir:
      - /install/REPO/software
      otherpkglist:
      - /install/xcat_clusters/osimage/rhels/common/otherpkglist/essl.otherpkglist
      - /install/xcat_clusters/osimage/rhels/common/otherpkglist/pessl.otherpkglist
      - /install/xcat_clusters/osimage/rhels/common/otherpkglist/xlc.otherpkglist
      - /install/xcat_clusters/osimage/rhels/common/otherpkglist/xlf.otherpkglist
      - /install/xcat_clusters/osimage/rhels/common/otherpkglist/PPT.otherpkglist
      - /install/xcat_clusters/osimage/rhels/common/otherpkglist/SMPI.otherpkglist
      - /install/xcat_clusters/osimage/rhels/common/otherpkglist/cuda.otherpkglist
      pkgdir:
      - /install/REPO/os/rhels/rhels7.5-alt-ga/ppc64le
      - /install/REPO/software/nvidia/cuda-dep/repo/ppc64le/
      pkglist:
      - /install/xcat_clusters/osimage/rhels/common/pkglist/all.df.pkglist
    provision_mode: install
    role: compute
    scripts:
      postbootscripts:
      - /install/postscripts/custom_postscripts/mountEMS_install.sh
      - /install/postscripts/custom_postscripts/syncfilesfromEMS.sh
schema_version: '1.0'

#Version 2.14.3 (git commit d74f1eed53ef385d80a9013d46c2a7cff1de06e4, built Wed Jul 18 06:15:52 EDT 2018)
```
import the definition file:
```
[root@c910f03c05k21 1.0]# xcat-inventory import -f /tmp/ist.redhat-alt.perf.custom.install.DF.yaml
Importing object: ist.redhat-alt.perf.custom.install.DF
Inventory import successfully!

[root@c910f03c05k21 1.0]# lsdef -t osimage -o ist.redhat-alt.perf.custom.install.DF -i usercomment
Object name: ist.redhat-alt.perf.custom.install.DF
    usercomment=rhels7.5,ist,cuda-9.2.88-396.29
```