### PR TITLE
 provide a script to compare the differences between objects in yaml/json files #82

### DIFF
--- a/xcat-inventory/xcclient/inventory/invdiff.py
+++ b/xcat-inventory/xcclient/inventory/invdiff.py
@@ -102,7 +102,7 @@ except InvalidFileException,e:
     exit(retcode)
 
 
-dt=deepdiff.DeepDiff(d1,d2,ignore_order=True,report_repetition=False,exclude_paths='',significant_digits=None,view='text',verbose_level=2)
+dt=deepdiff.DeepDiff(d1,d2,ignore_order=True,report_repetition=False,exclude_paths='',significant_digits=None,view='text',verbose_level=1)
 
 print("\n--- %s\n+++ %s"%(fn3,fn3))
 pprint.pprint(dt,indent=2)

--- a/xcat-inventory/xcclient/inventory/invdiff.py
+++ b/xcat-inventory/xcclient/inventory/invdiff.py
@@ -64,13 +64,27 @@ def dump2json(xcatobj, filename=None):
 def json2dict(jsonstr):
     return json.loads(jsonstr)
 
-if(len(sys.argv)!=3):
+if(len(sys.argv)!=4):
     print("invdiff <file1> <file2>",file=sys.stderr)
     exit(1)
 
 print("\n====================BEGIN=====================\n")
 fn1=sys.argv[1]
 fn2=sys.argv[2]
+fn3=sys.argv[3]
+
+#print("file1=%s"%(fn1))
+#print("file2=%s"%(fn2))
+
+if fn1=="/dev/null":
+    print("--- %s"%(fn1),file=sys.stdout)
+    print("+++ %s\n"%(fn3),file=sys.stdout)
+    exit(0)
+
+if fn2=="/dev/null":
+    print("--- %s"%(fn3),file=sys.stdout)
+    print("+++ %s\n"%(fn2),file=sys.stdout)
+    exit(0)
 
 
 try:
@@ -79,19 +93,20 @@ try:
 except InvalidFileException,e:
     (retcode,out,err)=runCommand("diff -u %s %s"%(fn1,fn2))    
     if out:
-        out=re.sub(r"%s"%(fn1),fn2,out)
+        out=re.sub(r"%s"%(fn2),fn3,out)
         print(out,file=sys.stdout) 
     if err:
-        err=re.sub(r"%s"%(fn1),fn2,err)
+        err=re.sub(r"%s"%(fn2),fn3,err)
         print(err,file=sys.stderr) 
     print("\n===================END======================\n")
     exit(retcode)
 
 
 dt=deepdiff.DeepDiff(d1,d2,ignore_order=True,report_repetition=False,exclude_paths='',significant_digits=None,view='text',verbose_level=2)
-print("\n--- %s\n+++ %s"%(fn2,fn2))
 
-
-
-print(dump2yaml(dict(dt)))
+print("\n--- %s\n+++ %s"%(fn3,fn3))
+pprint.pprint(dt,indent=2)
+#exit(0)
+#print(dump2yaml(json.loads(dt.json)))
+#print(dump2yaml((dt.json)))
 print("\n====================END=====================\n")

--- a/xcat-inventory/xcclient/inventory/invdiff.py
+++ b/xcat-inventory/xcclient/inventory/invdiff.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+from __future__ import print_function
+import deepdiff
+import pprint
+import yaml
+import json
+import sys
+
+
+def loadfile(filename):
+    contents={}
+    with open(filename,"r") as fh:
+        f=fh.read()
+        try:
+            contents=json.loads(f)
+        except ValueError:
+            try:
+                contents = yaml.load(f)
+            except Exception,e:
+                raise InvalidFileException("Error: failed to load file \"%s\", please validate the file with 'yamllint %s'(for yaml format) or 'cat %s|python -mjson.tool'(for json format)!"%(location,location,location))
+        return contents
+    return None
+
+def dump2yaml(xcatobj, location=None):
+    if not location:
+        print(yaml.safe_dump(xcatobj, default_flow_style=False,allow_unicode=True))
+    else:
+        f=open(location,'w')
+        print(yaml.safe_dump(xcatobj, default_flow_style=False,allow_unicode=True),file=f)
+
+    #TODO: store in file or directory
+
+def dump2json(xcatobj, location=None):
+    if not location:
+        print(json.dumps(xcatobj, sort_keys=True, indent=4, separators=(',', ': ')))
+    else:
+        f=open(location,'w')
+        print(json.dumps(xcatobj, sort_keys=True, indent=4, separators=(',', ': ')),file=f)
+
+
+def json2dict(jsonstr):
+    return json.loads(jsonstr)
+
+if(len(sys.argv)!=3):
+    print("invdiff <file1> <file2>",file=sys.stderr)
+    exit(1)
+
+fn1=sys.argv[1]
+fn2=sys.argv[2]
+
+
+d1=loadfile(filename=fn1)
+d2=loadfile(filename=fn2)
+
+
+
+
+dt=deepdiff.DeepDiff(d1,d2,ignore_order=True,report_repetition=False,exclude_paths='',significant_digits=None,view='text',verbose_level=2)
+print(dump2yaml(dict(dt)))


### PR DESCRIPTION
## for ticket:
https://github.com/xcat2/xcat-inventory/issues/82
This PR introduce a new opensource python module `deepdiff` https://github.com/seperman/deepdiff to provide wonderful object based diff 

## prequisite:
Install `deepdiff` from PyPi:
`pip install deepdiff`

## output
a nested dict, whose key is the type of modification:
 `dictionary_item_added` means:   newly added object 
`dictionary_item_removed`: removed object
 `iterable_item_added`:  newly added list object

the key of subdict is the nested keys to the modified attribute


## UT
```
[root@c910f03c05k21 inventory]# ./invdiff.py /tmp/osimage.yaml /tmp/osimage.yaml.bak
dictionary_item_added: !!set
  root['osimage']['cumulus3.4.1-amd64']: null
dictionary_item_removed: !!set
  root['osimage']['centos66-x86_64-install-compute']: null
iterable_item_added:
  root['osimage']['ist.redhat-alt.perf.custom.install.DF']['deprecated']['comments'][1]: ist

None
[root@c910f03c05k21 inventory]#
```