### PR TITLE
changing the default format to yaml

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -96,7 +96,7 @@ class InventoryFactory(object):
             InventoryFactory.__db__=dbfactory(self.dbsession)
         return InventoryFactory.__db__
 
-    def exportObjs(self, objlist, location=None,fmt='json',comment=None):
+    def exportObjs(self, objlist, location=None,fmt='yaml',comment=None):
         myclass = InventoryFactory.__InventoryClass__[self.objtype]
         myclass.loadschema(self.schemapath)
         myclass.validate_schema_version(None,'export')
@@ -192,11 +192,12 @@ class InventoryFactory(object):
         if self.schemapath:
             return os.path.basename(os.path.dirname(self.schemapath))
 
-def dumpobj(objdict, fmt='json',location=None):
-    if not fmt or fmt.lower() == 'json':
-        dump2json(objdict,location)
-    else:
+def dumpobj(objdict, fmt='yaml',location=None):
+    if not fmt or fmt.lower() == 'yaml':
         dump2yaml(objdict,location)
+    else:
+        dump2json(objdict,location)
+
 
 def dump2yaml(xcatobj, location=None):
     if not location:
@@ -267,12 +268,12 @@ def validate_args(args, action):
                 if et.lower() not in InventoryFactory.getvalidobjtypes():
                     raise CommandException("Error: Invalid object type to exclude: \"%(t)s\"", t=et)
 
-def export_by_type(objtype, names, destfile=None, destdir=None, fmt='json',version=None,exclude=None):
+def export_by_type(objtype, names, destfile=None, destdir=None, fmt='yaml',version=None,exclude=None):
     if objtype and objtype not in InventoryFactory.getObjTypesWithFiles()  and destdir:
         raise CommandException("Error: directory %(f)s specified by -f|--path is only supported when [-t|--type osimage|credential] or export all without [-t|--type] specified",f=destdir)
 
     if not fmt:
-        fmt='json'
+        fmt='yaml'
     InventoryFactory.getLatestSchemaVersion()
     dbsession=DBsession()
     
@@ -329,10 +330,11 @@ def export_by_type(objtype, names, destfile=None, destdir=None, fmt='json',versi
 
     if objtypelist:
         if destdir and exportall==1:
-            if not fmt or fmt.lower() == 'json':
-                mylocation=os.path.join(destdir,'cluster.json')
-            else:
+            if not fmt or fmt.lower() == 'yaml':
                 mylocation=os.path.join(destdir,'cluster.yaml')
+            else:
+                mylocation=os.path.join(destdir,'cluster.json')
+
             dumpobj(wholedict, fmt,mylocation)
             with open(mylocation, "a") as myfile:
                 myfile.write("#%s"%(xcatversion))
@@ -343,10 +345,11 @@ def export_by_type(objtype, names, destfile=None, destdir=None, fmt='json',versi
                 myfile.write("#%s"%(xcatversion))
             print("The inventory data has been dumped to %s"%(destfile))
         else: 
-            if not fmt or fmt.lower() == 'json':
-                dump2json(wholedict)
-            else:
+            if not fmt or fmt.lower() == 'yaml':
                 dump2yaml(wholedict)
+            else:
+                dump2json(wholedict)
+
             print("#%s"%(xcatversion))
     dbsession.close() 
 

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -51,7 +51,7 @@ class InventoryShell(shell.ClusterShell):
     @shell.arg('-f','--path', metavar='<path>', help='path of the inventory file')
     @shell.arg('-d','--dir', dest='directory',metavar='<directory>', help='path of the inventory directory')
     @shell.arg('-s','--schema-version', dest='version',metavar='<version>', help='schema version of the inventory data. Valid values: '+','.join(mgr.InventoryFactory.getAvailableSchemaVersions())+'. '+'If not specified, the "latest" schema version will be used')
-    @shell.arg('--format', metavar='<format>', help='format of the inventory data, valid values: json, yaml. json will be used by default if not specified ')
+    @shell.arg('--format', metavar='<format>', help='format of the inventory data, valid values: json, yaml. yaml will be used by default if not specified ')
     def do_export(self, args):
         """Export the inventory data from xcat database"""
         mgr.validate_args(args, 'export')


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-inventory/issues/88

UT:
```
[root@briggs01 tmp]# xcat-inventory export -t site
schema_version: '1.0'
site:
  clustersite:
    SNsyncfiledir: /var/xcat/syncfiles
    auditnosyslog: '0'
    auditskipcmds: ALL
    blademaxp: '64'
    cleanupxcatpost: 'no'
    consoleondemand: 'no'
    databaseloc: /var/lib
    db2installloc: /mntdb2
    dhcpinterfaces: briggs01.pok.stglabs.ibm.com|enP34p1s0f0,,enP34p1s0f0.12,enP34p1s0f1:noboot
    dhcplease: '300'
    disjointdhcps: '0'
    dnshandler: ddns
    domain: pok.stglabs.ibm.com
    enableASMI: 'no'
    forwarders: 10.6.29.1
    fsptimeout: '0'
    hierarchicalattrs: postscripts
    installdir: /install
    ipmimaxp: '64'
    ipmiretries: '3'
    ipmitimeout: '2'
    master: 172.12.253.27
    maxssh: '8'
    nameservers: 172.12.253.27
    nodesyncfiledir: /var/xcat/node/syncfiles
    ntpservers: <xcatmaster>
    powerinterval: '0'
    ppcmaxp: '64'
    ppcretry: '3'
    ppctimeout: '0'
    runbootscripts: '1'
    secureroot: '1'
    sharedtftp: '1'
    sshbetweennodes: ALLGROUPS
    svloglocal: '0'
    syspowerinterval: '0'
    tftpdir: /tftpboot
    timezone: America/New_York
    useNmapfromMN: 'no'
    vsftp: n
    xcatconfdir: /etc/xcat
    xcatdebugmode: '0'
    xcatdport: '3001'
    xcatiport: '3002'
    xcatmaxbatchconnections: '300'
    xcatmaxconnections: '356'
    xcatsslversion: TLSv1

#Version 2.14.3 (git commit d1bf861f7bae8e322a8d5b33f0729d5c3fe0a2b7, built Mon Aug 13 06:15:45 EDT 2018)
```