### PR TITLE
performance enhance: avoid running `lsxcatd -v` time to time

### DIFF
--- a/xcat-inventory/xcclient/inventory/globalvars.py
+++ b/xcat-inventory/xcclient/inventory/globalvars.py
@@ -1,0 +1,11 @@
+
+#xcat version string
+xcat_version=""
+
+#xcat version number
+xcat_verno=""
+
+#xcat service running?
+isxcatrunning=0
+
+

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -11,7 +11,7 @@ from dbfactory import dbfactory
 from xcatobj import *
 from exceptions import *
 from utils import *
-
+import globalvars
 import os
 import yaml
 import shutil
@@ -278,9 +278,7 @@ def export_by_type(objtype, names, destfile=None, destdir=None, fmt='yaml',versi
     dbsession=DBsession()
     
     xcatversion='XCAT Version'
-    (retcode,out,err)=runCommand('XCATBYPASS=1 lsxcatd -v')
-    if retcode==0:
-        xcatversion=out
+    xcatversion=globalvars.xcat_version
 
     objlist = []
     objtypelist=[]

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -16,6 +16,7 @@ import re
 import sys
 import traceback
 import os
+import utils
 
 try: 
     import xcclient.inventory.manager as mgr
@@ -67,6 +68,7 @@ class InventoryShell(shell.ClusterShell):
 
 # main entry for CLI
 def main():
+    utils.initglobal()
     try:
         InventoryShell('xcat-inventory','#VERSION_SUBSTITUTE#').run(sys.argv[1:], '1.0', "xCAT inventory management tool")
     except KeyboardInterrupt:

--- a/xcat-inventory/xcclient/inventory/utils.py
+++ b/xcat-inventory/xcclient/inventory/utils.py
@@ -10,6 +10,7 @@ import re
 import subprocess
 import json
 import yaml
+import globalvars
 
 def runCommand(cmd, env=None):
     """
@@ -86,3 +87,17 @@ def loadfile(filename):
         return contents, fmt
     return None, fmt
 
+#initialize the global vars in globalvars.py
+def initglobal():
+    if os.path.exists("/var/run/xcatd.pid"):
+        globalvars.isxcatrunning=1
+    else:
+        globalvars.isxcatrunning=0 
+    if globalvars.isxcatrunning:
+        (retcode,out,err)=runCommand("XCATBYPASS=0 lsxcatd -v")
+    else:
+        (retcode,out,err)=runCommand("XCATBYPASS=1 lsxcatd -v")
+    if retcode!=0:
+        xcat_version=""
+    globalvars.xcat_version=out.strip()
+    globalvars.xcat_verno=globalvars.xcat_version.split(' ')[1]

--- a/xcat-inventory/xcclient/inventory/vutil.py
+++ b/xcat-inventory/xcclient/inventory/vutil.py
@@ -12,6 +12,7 @@ import yaml
 import sys
 import re
 import utils
+import globalvars
 from distutils.version import LooseVersion, StrictVersion
 
 def isIPaddr(varin):
@@ -105,10 +106,7 @@ def strsubst(string,subdict={}):
     return string
 
 def xcatversion():
-    (retcode,out,err)=utils.runCommand("XCATBYPASS=1 lsxcatd -v|cut -d' ' -f2")
-    if retcode!=0:
-        return None
-    return LooseVersion(out.strip()) 
+    return LooseVersion(globalvars.xcat_verno)    
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
UT:
```
[root@briggs01 inventory]# time xcat-inventory export -tsite
schema_version: '1.0'
site:
  clustersite:
    SNsyncfiledir: /var/xcat/syncfiles
    auditnosyslog: '0'
    auditskipcmds: ALL
    blademaxp: '64'
    cleanupxcatpost: 'no'
    consoleondemand: 'no'
    databaseloc: /var/lib
    db2installloc: /mntdb2
    dhcpinterfaces: briggs01.pok.stglabs.ibm.com|enP34p1s0f0,,enP34p1s0f0.12,enP34p1s0f1:noboot
    dhcplease: '300'
    disjointdhcps: '0'
    dnshandler: ddns
    domain: pok.stglabs.ibm.com
    enableASMI: 'no'
    forwarders: 10.6.29.1
    fsptimeout: '0'
    hierarchicalattrs: postscripts
    installdir: /install
    ipmimaxp: '64'
    ipmiretries: '3'
    ipmitimeout: '2'
    master: 172.12.253.27
    maxssh: '8'
    nameservers: 172.12.253.27
    nodesyncfiledir: /var/xcat/node/syncfiles
    ntpservers: <xcatmaster>
    powerinterval: '0'
    ppcmaxp: '64'
    ppcretry: '3'
    ppctimeout: '0'
    runbootscripts: '1'
    secureroot: '1'
    sharedtftp: '1'
    sshbetweennodes: ALLGROUPS
    svloglocal: '0'
    syspowerinterval: '0'
    tftpdir: /tftpboot
    timezone: America/New_York
    useNmapfromMN: 'no'
    vsftp: n
    xcatconfdir: /etc/xcat
    xcatdebugmode: '0'
    xcatdport: '3001'
    xcatiport: '3002'
    xcatmaxbatchconnections: '300'
    xcatmaxconnections: '356'
    xcatsslversion: TLSv1

#Version 2.14.3 (git commit d1bf861f7bae8e322a8d5b33f0729d5c3fe0a2b7, built Mon Aug 13 06:15:45 EDT 2018)

real	0m1.211s
user	0m0.986s
sys	0m0.001s
```