### PR TITLE
implicit variable support

### DIFF
--- a/xcat-inventory/xcclient/inventory/globalvars.py
+++ b/xcat-inventory/xcclient/inventory/globalvars.py
@@ -8,4 +8,8 @@ xcat_verno=""
 #xcat service running?
 isxcatrunning=0
 
-
+implicitEnvVars={'OBJNAME':{'description':"the object name to import"},
+                 'GITROOT':{'description':"the root path of the git repo where the inventory file resides in"},
+                 'GITBRANCH':{'description':"the current git branch name of the inventory file to import"},
+                 'GITTAG':{'description':"the current git tag of the inventory file to import"},
+                 'GITCOMMIT':{'description':"the current git commit number of the inventory file to import"}}

--- a/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
@@ -78,7 +78,9 @@
       - "${{value=T{linuximage.postinstall},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : [x for x in vutil.strsubst(value,envars).split(',')] if value else None }} "
       - "W:T{linuximage.postinstall}=${{value=V{genimgoptions.postinstall}: ','.join(value) if type(value) == type([]) else value}}"
       - "F:${{flist=V{genimgoptions.postinstall}: [x for x in vutil.getfileanddeplist(flist) if not vutil.underpath(x,'/opt/xcat/share/xcat/')] }}"
-      rootimgdir: "T{linuximage.rootimgdir}"
+      rootimgdir: 
+      - "${{value=T{linuximage.rootimgdir},envars=dict([y.split('=')[1],'{{'+y.split('=')[0]+'}}'] for y in T{osimage.environvar}.split(',')) if T{osimage.environvar} else {} : vutil.strsubst(value,envars) if value else None }} "
+      - "W:T{linuximage.rootimgdir}=${{value=V{genimgoptions.rootimgdir}: value}}"
       nodebootif: "T{linuximage.nodebootif}"
       permission: "T{linuximage.permission}"
       rootfstype: 

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -66,6 +66,9 @@ class InventoryShell(shell.ClusterShell):
         from inventorydiff import InventoryDiff
         InventoryDiff(args.origin, args.new, args.type).ShowDiff()
 
+    def do_envlist(self,args):
+        """Show implicit environment variables during 'xcat-inventory import', which can be used in inventory files with format '{{<environment variable name>}}'"""
+        mgr.envlist()
 # main entry for CLI
 def main():
     utils.initglobal()

--- a/xcat-inventory/xcclient/inventory/utils.py
+++ b/xcat-inventory/xcclient/inventory/utils.py
@@ -41,6 +41,19 @@ def Util_rmnullindict(mydict):
                 del mydict[key]
 
 
+# replace the "{{x}}" variables in the value of dict "mydict" 
+# with the values of "vardict[x]"
+def Util_subvarsindict(mydict,vardict):
+    for key in mydict.keys():
+        if isinstance(mydict[key],dict):
+            Util_subvarsindict(mydict[key],vardict)
+        elif isinstance(mydict[key],list):
+            for idx,val in enumerate(mydict[key]):
+                if isinstance(val,str):
+                    mydict[key][idx]=re.sub(r'\{\{(.*)\}\}',lambda m:vardict.get(m.group(1)),val)
+        elif isinstance(mydict[key],str):
+            mydict[key]=re.sub(r'\{\{(.*)\}\}',lambda m:vardict.get(m.group(1)),mydict[key])
+            
 
 # get the dict value mydict[a][b][c] with key path a.b.c
 def Util_getdictval(mydict,keystr):

--- a/xcat-inventory/xcclient/inventory/vutil.py
+++ b/xcat-inventory/xcclient/inventory/vutil.py
@@ -102,7 +102,8 @@ def getfileanddeplist(infilelist):
 
 def strsubst(string,subdict={}):
     for k in subdict.keys():
-        string=string.replace(k,subdict[k])
+        if k:
+            string=string.replace(k,subdict[k])
     return string
 
 def xcatversion():


### PR DESCRIPTION
* expose several implicit variables in inventory file to import;
* add subcommand 'envlist' to show the description and usage of the implicit variables

UT:
```
[root@briggs01 tmp]# xcat-inventory envlist
#<Notice> : refer the variables in the inventory file with format "{{variable name}}"#

variable name   : description
GITBRANCH       : the current git branch name of the inventory file to import
GITCOMMIT       : the current git commit number of the inventory file to import
OBJNAME         : the object name to import
GITTAG          : the current git tag of the inventory file to import
GITROOT         : the root path of the git repo where the inventory file resides in
```

```
[root@briggs01 osimage]# cat ./myosimage.rh7.compute.netboot
osimage:
  myosimage.rh7.compute.netboot:
    basic_attributes:
      arch: ppc64le
      distribution: rhels7.4
      osdistro: rhels7.4-ppc64le
      osname: Linux
    diskpartitionspec: /install/osimages/{{OBJNAME}}/scripts/partfile
    filestosync:
    - {{GITROOT}}/{{OBJNAME}}/synclist
    genimgoptions:
      exlist:
      - {{GITROOT}}/netboot/rh/compute.rhels7.ppc64le.exlist
      permission: '755'
      postinstall:
      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall
      rootimgdir: /install/netboot/{{OBJNAME}}/{{GITBRANCH}}/{{GITTAG}}/{{GITCOMMIT}}/
    imagetype: linux
    package_selection:
      otherpkgdir:
      - /install/custom/osimage/{{OBJNAME}}/3rdpkgs/
      otherpkglist:
      - /install/custom/osimage/{{OBJNAME}}/3rd.pkglist
      pkgdir:
      - /install/rhels7.4/ppc64le
      pkglist:
      - /opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist
    provision_mode: netboot
    role: compute
    scripts:
      postbootscripts:
      - scriptC
      - scriptD
      postscripts:
      - scriptA
      - scriptB
schema_version: '1.0'

#Version 2.14.3 (git commit d74f1eed53ef385d80a9013d46c2a7cff1de06e4, built Wed Jul 18 06:15:52 EDT 2018)
[root@briggs01 osimage]#

[root@briggs01 osimage]# xcat-inventory import -f ./myosimage.rh7.compute.netboot
Importing object: myosimage.rh7.compute.netboot
Inventory import successfully!
[root@briggs01 osimage]# lsdef -t osimage -o myosimage.rh7.compute.netboot
Object name: myosimage.rh7.compute.netboot
    environvar=GITBRANCH=master,GITCOMMIT=1dab,OBJNAME=myosimage.rh7.compute.netboot,GITTAG=myosimage.rh7.compute.netboot-test-0.1,GITROOT=/home/yangsbj/xcat_clusters
    exlist=/home/yangsbj/xcat_clusters/netboot/rh/compute.rhels7.ppc64le.exlist
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.4-ppc64le
    osname=Linux
    osvers=rhels7.4
    otherpkgdir=/install/custom/osimage/myosimage.rh7.compute.netboot/3rdpkgs/
    otherpkglist=/install/custom/osimage/myosimage.rh7.compute.netboot/3rd.pkglist
    partitionfile=/install/osimages/myosimage.rh7.compute.netboot/scripts/partfile
    permission=755
    pkgdir=/install/rhels7.4/ppc64le
    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist
    postbootscripts=scriptC,scriptD
    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall
    postscripts=scriptA,scriptB
    profile=compute
    provmethod=netboot
    rootimgdir=/install/netboot/myosimage.rh7.compute.netboot/master/myosimage.rh7.compute.netboot-test-0.1/1dab/
    synclists=/home/yangsbj/xcat_clusters/myosimage.rh7.compute.netboot/synclist
```