### PR TITLE
support diff file with xcat db object

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Show usage info:
 # xcat-inventory help
 # xcat-inventory export -h
 # xcat-inventory import -h
+# xcat-inventory diff -h
 ```
 
 ### Export
@@ -228,6 +229,20 @@ xcat-inventory exposes several builtin variables, the values of the variables ar
 # xcat-inventory envlist
 ```
 
+ ### diff
+
+* Diff the given 2 inventory files, if with `--filename` option, will show this filename 
+```
+# xcat-inventory diff --files /tmp/cluster.json /root/cluster.json [--filename cluster.json]
+```
+* Diff the given inventory file with xCAT DB, only compare the objects in given inventory file
+```
+# xcat-inventory diff --source /tmp/cluster.json
+```
+* Diff the given inventory file with whole xCAT DB
+```
+# xcat-inventory diff --source /tmp/cluster.json --all
+```
 
 ## Usecase
 

--- a/xcat-inventory/xcclient/inventory/exceptions.py
+++ b/xcat-inventory/xcclient/inventory/exceptions.py
@@ -33,6 +33,8 @@ class ObjNonExistException(BaseException):
     pass
 class CommandException(BaseException):
     pass
+class FileNotExistException(BaseException):
+    pass
 class InvalidFileException(BaseException):
     pass
 class InternalException(BaseException):

--- a/xcat-inventory/xcclient/inventory/inventorydiff.py
+++ b/xcat-inventory/xcclient/inventory/inventorydiff.py
@@ -1,262 +1,99 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import utils
+from structurediff import StructureDiff
+import manager as mgr 
 from exceptions import *
-import deepdiff
-import yaml
-import json
-import sys
+from utils import *
 import re
 
-class format_diff_output(object):
-    def __init__(self, format_type):
-        self.format_type = format_type 
-        self.flag_dict = {'-diff': '-', '+diff': '+'}
+def line_diff(file1, file2):
+    (retcode,out,err)=runCommand("diff -u %s %s"%(file1, file2))
+    if out:
+        out=re.sub(r"%s.*"%(file1),file2,out)
+        out=re.sub(r"%s.*"%(file2),file2,out)
+    if err:
+        err=re.sub(r"%s.*"%(file1),file2,err)
+        err=re.sub(r"%s.*"%(file2),file2,err)
+    return out, err
 
-    def _get_path_as_list(self, path):
-        path_list = re.findall(r'(?<=\[\').+?(?=\'\])', path)
-        return path_list
-
-    def _update_dict(self, old_dict, new_dict):
-
-        if not old_dict and new_dict:
-            old_dict = new_dict
-            return old_dict
-
-        if type(new_dict) == list:
-            old_dict += new_dict
-            return old_dict
-
-        keys = new_dict.keys()
-        for key in keys:
-            if key in old_dict:
-                self._update_dict(old_dict[key], new_dict[key])
-            else:
-                old_dict.update({key: new_dict[key]})
-        return old_dict 
-
-    def _format_yaml(self, yamlstr):
-        yaml_list = yamlstr.split('\n')
-        new_list = []
-
-        while len(yaml_list) > 0:
-            tmp_str = yaml_list.pop(0)
-            diff_flag = None
-            flag = None
-            for key, flag in self.flag_dict.items():
-                if key in tmp_str:
-                    diff_flag = key
-                    break
-
-            if diff_flag:
-                null_num = 0
-                if diff_flag + ': ' in tmp_str:
-                    tmp_str = tmp_str.replace('%s: ' % diff_flag, '') 
-                    if tmp_str:
-                        tmp_str = flag + tmp_str.replace('\'', '')
-                        new_list.append(tmp_str)
-                else:
-                    null_num = tmp_str.count(' ')
-                    while len(yaml_list) > 0:
-                        tmp_str = yaml_list.pop(0)
-                        tmp_null_num = tmp_str.count(' ')
-                        if tmp_null_num > null_num:
-                            tmp_str = flag + tmp_str[2:]
-                            new_list.append(tmp_str)
-                        else:
-                            yaml_list.insert(0, tmp_str)
-                            break
-            else:
-                new_list.append(tmp_str) 
-
-        return ('\n'.join(new_list))
-
-    def _format_json(self, jsonstr):
-        json_list = jsonstr.split('\n')
-        new_list = []
-
-        while len(json_list) > 0:
-            tmp_str = json_list.pop(0)
-            diff_flag = None 
-            flag = None
-            for key, flag in self.flag_dict.items():
-                if key in tmp_str:
-                    diff_flag = key
-                    break
-
-            if diff_flag:
-                bracket = 0
-                if '{' in tmp_str:
-                    bracket += 1
-                    while (bracket > 0 and len(json_list) > 0):
-                        tmp_str = json_list.pop(0)
-                        if '{' in tmp_str:
-                            bracket += 1
-                        if '}' in tmp_str:
-                            bracket -= 1
-                            if not bracket:
-                                break
-                        tmp_str = flag + tmp_str[4:]
-                        new_list.append(tmp_str)
-                else:
-                    tmp_str = tmp_str.replace('%s: ' % diff_flag, '')
-                    tmp_str = flag + tmp_str
-                    new_list.append(tmp_str)
-        
-            else:
-                new_list.append(tmp_str)
-
-        return ('\n'.join(new_list))
-
-    def _deal_with_diff_dict(self, result_dict):
-        diff_dict = {}
-        for key, value in result_dict.items():
-            for change in value:
-                mychange = {}
-                if 'added' in key:
-                    if 'iterable' in key:
-                        path = self._get_path_as_list(change.up.path())
-                        extra = path.pop()
-                        mychange = {extra: ['+diff: %s' % change.t2]}
-                    else:
-                        path= self._get_path_as_list(change.path())
-                        extra = path.pop()
-                        mychange = { '+diff': {extra: change.t2}}
-                elif 'removed' in key: 
-                    if 'iterable' in key:
-                        path = self._get_path_as_list(change.up.path())
-                        extra = path.pop()
-                        mychange = {extra: ['-diff: %s' % change.t1]}
-                    else:
-                        path = self._get_path_as_list(change.path())
-                        extra = path.pop()
-                        mychange = {'-diff': {extra: change.t1}}
-                elif 'changed' in key:
-                    path = self._get_path_as_list(change.path())
-                    extra = path.pop()
-                    mychange = {'-diff': {extra: change.t1}, '+diff': {extra: change.t2}}
-
-                while len(path) > 0:
-                    key_str = path.pop()
-                    mychange = {key_str: mychange}
-
-                for change_key in mychange:
-                    diff_dict = self._update_dict(diff_dict, {change_key: mychange[change_key]}) 
-        return diff_dict
-
-    def get_diff_string(self, diff_dict):
-        final_dict = self._deal_with_diff_dict(diff_dict) 
-        if self.format_type == 'json':
-            diff_json = json.dumps(final_dict, indent=4, separators=(',', ': '))
-            return (self._format_json(diff_json))
-        else:
-            diff_yaml = yaml.safe_dump(final_dict, default_flow_style=False,allow_unicode=True)
-            return (self._format_yaml(diff_yaml))
 
 class InventoryDiff(object):
+    def __init__(self, args, check=False):
+        if check:
+            self._validate_args(args)
 
-    def __init__(self, objs, objtype, isgit=False):
-        self.objtype = objtype
-        if objtype == 'f':
-            self.obj1 = objs.pop(0)
-        else:
-            self.obj1 = 'xCAT_DB'
-        self.obj2 = objs.pop(0)
-        self.isgit = isgit
-        self.fmt = 'json'
+    def _validate_args(self, args):
+        if args.files and args.source:
+            raise CommandException("Error: '--files' and '--source' cannot be used together!")
+        if not args.files and not args.source:
+            raise CommandException("Error: No valid source type!")
+        if not args.source and args.all:
+            raise CommandException("Error: '--all' must be used with '--source'!")
+        if not args.files and args.fn:
+            raise CommandException("Error: '--fn' must be used with '--files'!")
+
+        if args.files:
+            self.objs = args.files
+            self.objtype = 'f'
+            self.filename = args.fn
+        elif args.source:
+            self.objs = args.source
+            self.objtype = 'fvso'
+        self.isall = args.all
 
     def _get_file_data(self, data_file):
-        data, self.fmt = utils.loadfile(filename=data_file)
+        data, self.fmt = loadfile(filename=data_file)
         return data
 
-    def _diff_with_cmd(self):
-        (retcode,out,err)=utils.runCommand("diff -u %s %s"%(self.obj1,self.obj2))
-        if out:
-            out=re.sub(r"%s.*"%(self.obj1),self.obj2,out)
-            out=re.sub(r"%s.*"%(self.obj2),self.obj2,out)
-        if err:
-            err=re.sub(r"%s.*"%(self.obj1),self.obj2,err)
-            err=re.sub(r"%s.*"%(self.obj2),self.obj2,err)
-        return out, err
+    def show_diff(self, diff, source=None):
+        print("\n====================BEGIN=====================\n")
+        if source:
+            print(source)
+        print(diff)
+        print("\n====================END=====================\n")
 
-    def _filter_DB_keys(self, d1, d2):
-        for key in d1.keys():
-            if key not in d2:
-                del d1[key]
-                continue
-            if type(d1[key]) != dict:
-                continue
-            for subkey in d1[key].keys():
-                if subkey not in d2[key]:
-                    del d1[key][subkey]
-
-    def ShowDiff(self):
+    def inventory_diff(self):
         rc = None
-        out = None
+        err = None
         if self.objtype == 'f':
+            file1 = self.objs.pop(0)
+            file2 = self.objs.pop(0)
             try:
-                d1 = self._get_file_data(self.obj1)
-                d2 = self._get_file_data(self.obj2)
+                d1 = self._get_file_data(file1)
+                d2 = self._get_file_data(file2)
             except FileNotExistException as e:
                 err = e.message
                 rc = 1
             except InvalidFileException as e:
-                out, err = self._diff_with_cmd()
+                out, err = line_diff(file1, file2)
                 rc = 1
+            if self.filename:
+                file1 = self.filename
+                file2 = self.filename
         elif self.objtype == 'fvso':
+            file1 = 'xCAT DB'
+            file2 = self.objs.pop(0)
             try:
-                d2 = self._get_file_data(self.obj2) 
+                d2 = self._get_file_data(file2)
                 if type(d2) != dict:
-                    err = 'Error: Format of data from file \'%s\' is not correct, please check...' % self.obj2
+                    err = 'Error: Format of data from file \'%s\' is not correct, please check...' % file2
                     rc = 1
             except FileNotExistException as e:
                 err = e.message
                 rc = 1
             except InvalidFileException as e:
-                err = 'Error: Could not get json or yaml data from file \'%s\', please check or export object to diff files' % self.obj2
-                rc = 1 
-
+                err = 'Error: Could not get json or yaml data from file \'%s\', please check or export object to diff files' % file2
+                rc = 1
             if not rc:
-                import xcclient.inventory.manager as mgr
                 d1 = mgr.export_by_type(None, None, fmt='dict')
-                self._filter_DB_keys(d1, d2)
-        else:
-            d1 = self.obj1
-            d2 = self.obj2
 
         if rc and err:
             return print(err)
 
-        print("\n====================BEGIN=====================\n")
         if not rc:
-            dt = deepdiff.DeepDiff(d1,d2,ignore_order=True,report_repetition=False,exclude_paths='',significant_digits=None,view='tree',verbose_level=1)
-            diff_out = format_diff_output(self.fmt).get_diff_string(dt)
+            diff_dict = StructureDiff().diff(d1, d2, self.isall)
+            self.show_diff(StructureDiff().repet(diff_dict, self.fmt), "\n--- %s\n+++ %s" % (file1, file2))
+        elif out:
+            self.show_diff(out)
 
-            if self.isgit:
-                print("\n--- %s\n+++ %s"%(self.obj2, self.obj2))
-            else:
-                print("\n--- %s\n+++ %s"%(self.obj1, self.obj2))
-
-            if diff_out and diff_out != '{}':
-                print(diff_out)
-            else:
-                print('No difference')
-        else:
-            if out:
-                print(out) 
-        print("\n====================END=====================\n")
-
-def validate_args(args):
-    if args.files and args.source:
-        raise CommandException("Error: --files and --source cannot be used together!")
-    if not args.files and not args.source:
-        raise CommandException("Error: No valid source type!")
-
-    if args.files:
-        objs = args.files
-        objtype = 'f'
-    elif args.source:
-        objs = args.source
-        objtype = 'fvso'
-    return (objs, objtype)

--- a/xcat-inventory/xcclient/inventory/inventorydiff.py
+++ b/xcat-inventory/xcclient/inventory/inventorydiff.py
@@ -19,9 +19,8 @@ def line_diff(file1, file2):
 
 
 class InventoryDiff(object):
-    def __init__(self, args, check=False):
-        if check:
-            self._validate_args(args)
+    def __init__(self, args):
+        self._validate_args(args)
 
     def _validate_args(self, args):
         if args.files and args.source:
@@ -30,13 +29,13 @@ class InventoryDiff(object):
             raise CommandException("Error: No valid source type!")
         if not args.source and args.all:
             raise CommandException("Error: '--all' must be used with '--source'!")
-        if not args.files and args.fn:
-            raise CommandException("Error: '--fn' must be used with '--files'!")
+        if not args.files and args.filename:
+            raise CommandException("Error: '--filename' must be used with '--files'!")
 
         if args.files:
             self.objs = args.files
             self.objtype = 'f'
-            self.filename = args.fn
+            self.filename = args.filename
         elif args.source:
             self.objs = args.source
             self.objtype = 'fvso'
@@ -93,7 +92,7 @@ class InventoryDiff(object):
 
         if not rc:
             diff_dict = StructureDiff().diff(d1, d2, self.isall)
-            self.show_diff(StructureDiff().repet(diff_dict, self.fmt), "\n--- %s\n+++ %s" % (file1, file2))
+            self.show_diff(StructureDiff().rept(diff_dict, self.fmt), "\n--- %s\n+++ %s" % (file1, file2))
         elif out:
             self.show_diff(out)
 

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -350,6 +350,9 @@ def export_by_type(objtype, names, destfile=None, destdir=None, fmt='yaml',versi
         else: 
             if not fmt or fmt.lower() == 'yaml':
                 dump2yaml(wholedict)
+            elif fmt == 'dict':
+                dbsession.close()
+                return wholedict
             else:
                 dump2json(wholedict)
 

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -58,14 +58,14 @@ class InventoryShell(shell.ClusterShell):
         mgr.validate_args(args, 'export')
         mgr.export_by_type(args.type, args.name, args.path, args.directory, args.format, version=args.version, exclude=args.exclude.split(','))
 
-    @shell.arg('--files', dest='files', metavar='FILE', nargs=2, help='compare the given 2 files')
-    @shell.arg('--fn', dest='fn', metavar='FILENAME', help='the filename want to show, be used with "--files"')
-    @shell.arg('--source', dest='source', metavar='FILE', nargs=1, help='compare the given inventory file with xCAT DB, default is just compare objects file contains')
-    @shell.arg('--all', dest='all', action="store_true", default=False, help='compare the given inventory file with the whole xCAT DB, be used with "--source"')
+    @shell.arg('--files', dest='files', metavar='FILE', nargs=2, help='compare the given 2 inventory files')
+    @shell.arg('--filename', dest='filename', metavar='FILENAME', nargs=1, help='the filename want to show, be used with "--files"')
+    @shell.arg('--source', dest='source', metavar='FILE', nargs=1, help='compare the given inventory file with xCAT DB')
+    @shell.arg('--all', dest='all', action="store_true", default=False, help='compare the given inventory file with the whole xCAT DB, be used with "--source". If not specified, will only compare the objects in given inventory file by default.')
     def do_diff(self, args):
         """Diff files or file vs xCAT DB"""
         from inventorydiff import InventoryDiff
-        InventoryDiff(args, True).inventory_diff()
+        InventoryDiff(args).inventory_diff()
 
     def do_envlist(self,args):
         """Show implicit environment variables during 'xcat-inventory import', which can be used in inventory files with format '{{<environment variable name>}}'"""

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -63,7 +63,7 @@ class InventoryShell(shell.ClusterShell):
     @shell.arg('--source', dest='source', metavar='FILE', nargs=1, help='compare the given inventory file with xCAT DB')
     @shell.arg('--all', dest='all', action="store_true", default=False, help='compare the given inventory file with the whole xCAT DB, be used with "--source". If not specified, will only compare the objects in given inventory file by default.')
     def do_diff(self, args):
-        """Diff files or file vs xCAT DB"""
+        """show inventory diff between files or file vs xCAT DB"""
         from inventorydiff import InventoryDiff
         InventoryDiff(args).inventory_diff()
 

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -52,23 +52,25 @@ class InventoryShell(shell.ClusterShell):
     @shell.arg('-f','--path', metavar='<path>', help='path of the inventory file')
     @shell.arg('-d','--dir', dest='directory',metavar='<directory>', help='path of the inventory directory')
     @shell.arg('-s','--schema-version', dest='version',metavar='<version>', help='schema version of the inventory data. Valid values: '+','.join(mgr.InventoryFactory.getAvailableSchemaVersions())+'. '+'If not specified, the "latest" schema version will be used')
-    @shell.arg('--format', metavar='<format>', help='format of the inventory data, valid values: json, yaml. yaml will be used by default if not specified ')
+    @shell.arg('--format', metavar='<format>', help='format of the inventory data, valid values: json, yaml. json will be used by default if not specified ')
     def do_export(self, args):
         """Export the inventory data from xcat database"""
         mgr.validate_args(args, 'export')
         mgr.export_by_type(args.type, args.name, args.path, args.directory, args.format, version=args.version, exclude=args.exclude.split(','))
 
-    @shell.arg('-o', '--origin', metavar='origin', help='origin file want to be compared')
-    @shell.arg('-n', '--new', metavar='new', help='new file want to be compared')
-    @shell.arg('-t', '--type', metavar='<type>', help='file source type, supported "git", "normal", default is "normal"')
+    @shell.arg('--files', dest='files', metavar='FILE', nargs=2, help='specify source type is file and specify 2 files')
+    @shell.arg('--source', dest='source', metavar='FILE', nargs=1, help='specify source type is file compared with xCAT DB and specify the file')
+    @shell.arg('--git', dest='git', action="store_true", default=False, help='git source. If true, the file source is from git')
     def do_diff(self, args):
-        """Diff two files"""
-        from inventorydiff import InventoryDiff
-        InventoryDiff(args.origin, args.new, args.type).ShowDiff()
+        """Diff files or file vs xCAT DB"""
+        from inventorydiff import validate_args, InventoryDiff
+        objs, objtype = validate_args(args)
+        InventoryDiff(objs, objtype, args.git).ShowDiff()
 
     def do_envlist(self,args):
         """Show implicit environment variables during 'xcat-inventory import', which can be used in inventory files with format '{{<environment variable name>}}'"""
         mgr.envlist()
+
 # main entry for CLI
 def main():
     utils.initglobal()

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -52,20 +52,20 @@ class InventoryShell(shell.ClusterShell):
     @shell.arg('-f','--path', metavar='<path>', help='path of the inventory file')
     @shell.arg('-d','--dir', dest='directory',metavar='<directory>', help='path of the inventory directory')
     @shell.arg('-s','--schema-version', dest='version',metavar='<version>', help='schema version of the inventory data. Valid values: '+','.join(mgr.InventoryFactory.getAvailableSchemaVersions())+'. '+'If not specified, the "latest" schema version will be used')
-    @shell.arg('--format', metavar='<format>', help='format of the inventory data, valid values: json, yaml. json will be used by default if not specified ')
+    @shell.arg('--format', metavar='<format>', help='format of the inventory data, valid values: json, yaml. yaml will be used by default if not specified ')
     def do_export(self, args):
         """Export the inventory data from xcat database"""
         mgr.validate_args(args, 'export')
         mgr.export_by_type(args.type, args.name, args.path, args.directory, args.format, version=args.version, exclude=args.exclude.split(','))
 
-    @shell.arg('--files', dest='files', metavar='FILE', nargs=2, help='specify source type is file and specify 2 files')
-    @shell.arg('--source', dest='source', metavar='FILE', nargs=1, help='specify source type is file compared with xCAT DB and specify the file')
-    @shell.arg('--git', dest='git', action="store_true", default=False, help='git source. If true, the file source is from git')
+    @shell.arg('--files', dest='files', metavar='FILE', nargs=2, help='compare the given 2 files')
+    @shell.arg('--fn', dest='fn', metavar='FILENAME', help='the filename want to show, be used with "--files"')
+    @shell.arg('--source', dest='source', metavar='FILE', nargs=1, help='compare the given inventory file with xCAT DB, default is just compare objects file contains')
+    @shell.arg('--all', dest='all', action="store_true", default=False, help='compare the given inventory file with the whole xCAT DB, be used with "--source"')
     def do_diff(self, args):
         """Diff files or file vs xCAT DB"""
-        from inventorydiff import validate_args, InventoryDiff
-        objs, objtype = validate_args(args)
-        InventoryDiff(objs, objtype, args.git).ShowDiff()
+        from inventorydiff import InventoryDiff
+        InventoryDiff(args, True).inventory_diff()
 
     def do_envlist(self,args):
         """Show implicit environment variables during 'xcat-inventory import', which can be used in inventory files with format '{{<environment variable name>}}'"""

--- a/xcat-inventory/xcclient/inventory/structurediff.py
+++ b/xcat-inventory/xcclient/inventory/structurediff.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import deepdiff
+from utils import *
+import yaml
+import json
+import sys
+import re
+
+class format_diff_output(object):
+    def __init__(self):
+        self.flag_dict = {'-diff': '-', '+diff': '+'}
+
+    def _get_path_as_list(self, path):
+        path_list = re.findall(r'(?<=\[\').+?(?=\'\])', path)
+        return path_list
+
+    def _update_dict(self, old_dict, new_dict):
+
+        if not old_dict and new_dict:
+            old_dict = new_dict
+            return old_dict
+
+        if type(new_dict) == list:
+            old_dict += new_dict
+            return old_dict
+
+        keys = new_dict.keys()
+        for key in keys:
+            if key in old_dict:
+                self._update_dict(old_dict[key], new_dict[key])
+            else:
+                old_dict.update({key: new_dict[key]})
+        return old_dict 
+
+    def _format_yaml(self, yamlstr):
+        yaml_list = yamlstr.split('\n')
+        new_list = []
+
+        while len(yaml_list) > 0:
+            tmp_str = yaml_list.pop(0)
+            diff_flag = None
+            flag = None
+            for key, flag in self.flag_dict.items():
+                if key in tmp_str:
+                    diff_flag = key
+                    break
+
+            if diff_flag:
+                null_num = 0
+                if diff_flag + ': ' in tmp_str:
+                    tmp_str = tmp_str.replace('%s: ' % diff_flag, '') 
+                    if tmp_str:
+                        tmp_str = flag + tmp_str.replace('\'', '')
+                        new_list.append(tmp_str)
+                else:
+                    null_num = tmp_str.count(' ')
+                    while len(yaml_list) > 0:
+                        tmp_str = yaml_list.pop(0)
+                        tmp_null_num = tmp_str.count(' ')
+                        if tmp_null_num > null_num:
+                            tmp_str = flag + tmp_str[2:]
+                            new_list.append(tmp_str)
+                        else:
+                            yaml_list.insert(0, tmp_str)
+                            break
+            else:
+                new_list.append(tmp_str) 
+
+        return ('\n'.join(new_list))
+
+    def _format_json(self, jsonstr):
+        json_list = jsonstr.split('\n')
+        new_list = []
+
+        while len(json_list) > 0:
+            tmp_str = json_list.pop(0)
+            diff_flag = None 
+            flag = None
+            for key, flag in self.flag_dict.items():
+                if key in tmp_str:
+                    diff_flag = key
+                    break
+
+            if diff_flag:
+                bracket = 0
+                if '{' in tmp_str:
+                    bracket += 1
+                    while (bracket > 0 and len(json_list) > 0):
+                        tmp_str = json_list.pop(0)
+                        if '{' in tmp_str:
+                            bracket += 1
+                        if '}' in tmp_str:
+                            bracket -= 1
+                            if not bracket:
+                                break
+                        tmp_str = flag + tmp_str[4:]
+                        new_list.append(tmp_str)
+                else:
+                    tmp_str = tmp_str.replace('%s: ' % diff_flag, '')
+                    tmp_str = flag + tmp_str
+                    new_list.append(tmp_str)
+        
+            else:
+                new_list.append(tmp_str)
+
+        return ('\n'.join(new_list))
+
+    def deal_with_diff_dict(self, result_dict):
+        diff_dict = {}
+        for key, value in result_dict.items():
+            for change in value:
+                mychange = {}
+                if 'added' in key:
+                    if 'iterable' in key:
+                        path = self._get_path_as_list(change.up.path())
+                        extra = path.pop()
+                        mychange = {extra: ['+diff: %s' % change.t2]}
+                    else:
+                        path= self._get_path_as_list(change.path())
+                        extra = path.pop()
+                        mychange = { '+diff': {extra: change.t2}}
+                elif 'removed' in key: 
+                    if 'iterable' in key:
+                        path = self._get_path_as_list(change.up.path())
+                        extra = path.pop()
+                        mychange = {extra: ['-diff: %s' % change.t1]}
+                    else:
+                        path = self._get_path_as_list(change.path())
+                        extra = path.pop()
+                        mychange = {'-diff': {extra: change.t1}}
+                elif 'changed' in key:
+                    path = self._get_path_as_list(change.path())
+                    extra = path.pop()
+                    mychange = {'-diff': {extra: change.t1}, '+diff': {extra: change.t2}}
+
+                while len(path) > 0:
+                    key_str = path.pop()
+                    mychange = {key_str: mychange}
+
+                for change_key in mychange:
+                    diff_dict = self._update_dict(diff_dict, {change_key: mychange[change_key]}) 
+        return diff_dict
+
+    def get_diff_string(self, format_type, diff_dict):
+        if format_type == 'json':
+            diff_json = json.dumps(diff_dict, indent=4, separators=(',', ': '))
+            return (self._format_json(diff_json))
+        else:
+            diff_yaml = yaml.safe_dump(diff_dict, default_flow_style=False,allow_unicode=True)
+            return (self._format_yaml(diff_yaml))
+
+
+class StructureDiff(object):
+
+    def __init__(self):
+        pass
+
+    def _get_deepdiff(self, obj1, obj2):
+        self.diff = deepdiff.DeepDiff(obj1,obj2,ignore_order=True,report_repetition=False,exclude_paths='',significant_digits=None,view='tree',verbose_level=1)
+
+    def repet(self, diff_dict, fmt):
+        diff_string = format_diff_output().get_diff_string(fmt, diff_dict)
+
+        if diff_string and diff_string != '{}':
+            return diff_string
+        else:
+            return 'No difference'
+
+    def diff(self, obj1, obj2, isall=False):
+        if not isall:
+            obj1 = filter_dict_keys(obj1, obj2)
+        self._get_deepdiff(obj1, obj2)
+        diff_dict = format_diff_output().deal_with_diff_dict(self.diff) 
+        return diff_dict

--- a/xcat-inventory/xcclient/inventory/structurediff.py
+++ b/xcat-inventory/xcclient/inventory/structurediff.py
@@ -160,7 +160,7 @@ class StructureDiff(object):
     def _get_deepdiff(self, obj1, obj2):
         self.diff = deepdiff.DeepDiff(obj1,obj2,ignore_order=True,report_repetition=False,exclude_paths='',significant_digits=None,view='tree',verbose_level=1)
 
-    def repet(self, diff_dict, fmt):
+    def rept(self, diff_dict, fmt):
         diff_string = format_diff_output().get_diff_string(fmt, diff_dict)
 
         if diff_string and diff_string != '{}':

--- a/xcat-inventory/xcclient/inventory/utils.py
+++ b/xcat-inventory/xcclient/inventory/utils.py
@@ -86,7 +86,7 @@ def Util_setdictval(mydict,keystr,value):
 
 def loadfile(filename):
     if not os.path.exists(filename):
-        raise FileNotExistException("Error: File %s does not exist, please check..." % filename)
+        raise FileNotExistException("Error: File '%s' does not exist, please check..." % filename)
 
     contents={}
     fmt = 'json'
@@ -118,3 +118,17 @@ def initglobal():
         xcat_version=""
     globalvars.xcat_version=out.strip()
     globalvars.xcat_verno=globalvars.xcat_version.split(' ')[1]
+
+# if "key" of d1 or "key" of d1[key] not in d2, delete it
+def filter_dict_keys(d1, d2):
+    tmp_d1 = d1
+    for key in tmp_d1.keys():
+        if key not in d2:
+            del tmp_d1[key]
+            continue
+        if type(tmp_d1[key]) != dict:
+            continue
+        for subkey in tmp_d1[key].keys():
+            if subkey not in d2[key]:
+                del tmp_d1[key][subkey]
+    return tmp_d1

--- a/xcat-inventory/xcclient/inventory/utils.py
+++ b/xcat-inventory/xcclient/inventory/utils.py
@@ -11,6 +11,7 @@ import subprocess
 import json
 import yaml
 import globalvars
+from exceptions import *
 
 def runCommand(cmd, env=None):
     """
@@ -84,6 +85,9 @@ def Util_setdictval(mydict,keystr,value):
             mydict[key]=value
 
 def loadfile(filename):
+    if not os.path.exists(filename):
+        raise FileNotExistException("Error: File %s does not exist, please check..." % filename)
+
     contents={}
     fmt = 'json'
     with open(filename,"r") as fh:


### PR DESCRIPTION
#106 

* CLI -- return a dict with diff
```
diff_dict = StructureDiff().diff(d1, d2, self.isall)
```

diff_dict like this:
```
{'node': {'c910f03c17': {'engines': {'hardware_mgt_engine': {'engine_info': {'-diff': {'bmc': '50.3.17.1'}}}}}}, '-diff': {'schema_version': 'latest'}, '+diff': {'schema_version': '1.0'}}
```

* UT:
```
# xcat-inventory diff -h
usage: xcat-inventory diff [--files FILE FILE] [--filename FILENAME]
                           [--source FILE] [--all]

Diff files or file vs xCAT DB

Arguments:
  --files FILE FILE    compare the given 2 inventory files
  --filename FILENAME  the filename want to show, be used with "--files"
  --source FILE        compare the given inventory file with xCAT DB
  --all                compare the given inventory file with the whole xCAT
                       DB, be used with "--source". If not specified, will
                       only compare the objects in given inventory file by
                       default.
```

```
#  xcat-inventory diff --files /tmp/cluster.json
usage: xcat-inventory diff [--files FILE FILE] [--filename FILENAME]
                           [--source FILE] [--all]
xcat-inventory diff: error: argument --files: expected 2 argument(s)

# xcat-inventory diff --files c910cluster/hardware_admin/xcat-inventory/c910f03c17k21/cluster.json /tmp/cluster.json --source /tmp/cluster.json
Error: --files and --source cannot be used together!

# xcat-inventory diff --files c910cluster/hardware_admin/xcat-inventory/c910f03c17k21/cluster.json /tmp/cluster.
Error: File '/tmp/cluster.' does not exist, please check...

# xcat-inventory diff --files c910cluster/hardware_admin/xcat-inventory/c910f03c17k21/cluster.json /tmp/cluster.json --all
Error: '--all' must be used with '--source'!
```

```
# xcat-inventory diff --source /tmp/cluster.json

====================BEGIN=====================


--- xCAT_DB
+++ /tmp/cluster.json
{
    "node": {
        "c910f03c17": {
            "engines": {
                "hardware_mgt_engine": {
                    "engine_info": {
-                        "bmc": "50.3.17.1"
                    }
                }
            }
        }
    },
-    "schema_version": "latest"
+    "schema_version": "1.0"
}

====================END=====================
```