### PR TITLE
refine node schema validation criteria

### DIFF
--- a/xcat-inventory/xcclient/inventory/schema/0.1/node.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/0.1/node.yaml
@@ -63,7 +63,7 @@
         - "C:${{seclevel=V{security_info.snmp.securitylevel}: True if str(seclevel) in  ('', 'noAuthNoPriv','authNoPriv','authPriv') else False}}"
         version: 
         - "${{devtype=V{device_type}: T{switches.snmpversion} if devtype == 'switch' else T{pdu.snmpversion} if devtype in ['pdu'] else None}}"
-        - "C:${{version=V{security_info.snmp.version}: True if str(version) in ('','1','2','3','SNMPv1','SNMPv2','SNMPv3') else False}}"
+        - "C:${{version=V{security_info.snmp.version}: True if str(version) in ('','1','2','2c','3','SNMPv1','SNMPv2','SNMPv3') else False}}"
         authprotocol: 
         - "${{ devtype=V{device_type}: T{switches.auth} if devtype in ['switch'] else T{pdu.authtype} if devtype in ['pdu']  else None  }}" 
         - "C:${{authtype=V{security_info.snmp.authprotocol}: True if str(authtype).upper() in ('','MD5','SHA') else False}}"
@@ -98,7 +98,6 @@
         switch: "T{switch.switch}"
         switchport: 
         - "T{switch.port}"
-        - "C:${{swport=V{network_info.primarynic.switchport}: False if swport and not vutil.isPort(swport) and not vutil.isRegex(swport) else True}}"
         switchvlan: "T{switch.vlan}"
         switchinterface: "T{switch.interface}"
       nics:

--- a/xcat-inventory/xcclient/inventory/schema/0.2/node.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/0.2/node.yaml
@@ -63,7 +63,7 @@
         - "C:${{seclevel=V{security_info.snmp.securitylevel}: True if str(seclevel) in  ('', 'noAuthNoPriv','authNoPriv','authPriv') else False}}"
         version: 
         - "${{devtype=V{device_type}: T{switches.snmpversion} if devtype == 'switch' else T{pdu.snmpversion} if devtype in ['pdu'] else None}}"
-        - "C:${{version=V{security_info.snmp.version}: True if str(version) in ('','1','2','3','SNMPv1','SNMPv2','SNMPv3') else False}}"
+        - "C:${{version=V{security_info.snmp.version}: True if str(version) in ('','1','2','2c','3','SNMPv1','SNMPv2','SNMPv3') else False}}"
         authprotocol: 
         - "${{ devtype=V{device_type}: T{switches.auth} if devtype in ['switch'] else T{pdu.authtype} if devtype in ['pdu']  else None  }}" 
         - "C:${{authtype=V{security_info.snmp.authprotocol}: True if str(authtype).upper() in ('','MD5','SHA') else False}}"
@@ -98,7 +98,6 @@
         switch: "T{switch.switch}"
         switchport: 
         - "T{switch.port}"
-        - "C:${{swport=V{network_info.primarynic.switchport}: False if swport and not vutil.isPort(swport) and not vutil.isRegex(swport) else True}}"
         switchvlan: "T{switch.vlan}"
         switchinterface: "T{switch.interface}"
       nics:


### PR DESCRIPTION
fix issue :https://github.com/xcat2/xcat-inventory/issues/113:

* remove the validation criteria for `network_info.primarynic.switchport `
* add "2c" to the legacy values for `security_info.snmp.version `


UT: 

```

mporting object: mgmtImporting object: publicImporting object: systemImporting object: ipmiImporting object: omapiImporting object: openbmcImporting object: alpinetdsImporting object: extgwyImporting object: 4.5Importing object: 4.4Importing object: 4.7Importing object: 4.6Importing object: 1.2Importing object: 4.9Importing object: 4.8Importing object: 1Importing object: 3Importing object: 2Importing object: 4Importing object: 2.3Importing object: 2.1Inventory import successfully!
--



```