### PR TITLE
fix add more verbose information during xcat-inventory import #117

### DIFF
--- a/makepythonrpm
+++ b/makepythonrpm
@@ -12,7 +12,7 @@ function makepythoncli {
     tar --exclude .svn -czvf $RPMROOT/SOURCES/$RPMNAME-${VERSION}.tar.gz $RPMNAME
     rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VERSION*rpm
     echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$VERSION*.noarch.rpm $EMBEDTXT..."
-    rpmbuild --quiet -ta $RPMROOT/SOURCES/$RPMNAME-${VERSION}.tar.gz --define "version $VERSION" --define "release c$NUMCOMMITS" --define "gitcommit $GITCOMMIT"
+    rpmbuild -v -v -v -ta $RPMROOT/SOURCES/$RPMNAME-${VERSION}.tar.gz --define "version $VERSION" --define "release c$NUMCOMMITS" --define "gitcommit $GITCOMMIT"
     if [ $? -eq 0 ]; then
         ls $RPMROOT/RPMS/noarch/$RPMNAME-$VERSION*.noarch.rpm
         exit 0

--- a/xcat-inventory/xcclient/inventory/dbfactory.py
+++ b/xcat-inventory/xcclient/inventory/dbfactory.py
@@ -6,6 +6,7 @@ from dbsession import DBsession
 from sqlalchemy import or_
 #from xcclient.shell import CommandException
 from exceptions import *
+import utils
 
 def create_or_update(session,tabcls,key,newdict,ismatrixtable=True):
     tabkey=tabcls.getkey()
@@ -107,7 +108,7 @@ class matrixdbfactory():
         if tabdict is None:
             return None
         for key in tabdict.keys():
-            print("  writing object: "+str(key),file=sys.stderr)
+            utils.verbose("  writting object: "+str(key),file=sys.stderr)
             for tab in tabdict[key].keys():
                 dbsession=self._dbsession.loadSession(tab);
                 if hasattr(dbobject,tab):

--- a/xcat-inventory/xcclient/inventory/dbfactory.py
+++ b/xcat-inventory/xcclient/inventory/dbfactory.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function
 import dbobject
 from dbobject import *
 from dbsession import DBsession
@@ -106,7 +107,7 @@ class matrixdbfactory():
         if tabdict is None:
             return None
         for key in tabdict.keys():
-            print("Importing object: "+str(key))
+            print("  writing object: "+str(key),file=sys.stderr)
             for tab in tabdict[key].keys():
                 dbsession=self._dbsession.loadSession(tab);
                 if hasattr(dbobject,tab):

--- a/xcat-inventory/xcclient/inventory/globalvars.py
+++ b/xcat-inventory/xcclient/inventory/globalvars.py
@@ -13,3 +13,6 @@ implicitEnvVars={'OBJNAME':{'description':"the object name to import"},
                  'GITBRANCH':{'description':"the current git branch name of the inventory file to import"},
                  'GITTAG':{'description':"the current git tag of the inventory file to import"},
                  'GITCOMMIT':{'description':"the current git commit number of the inventory file to import"}}
+
+#verbose?
+verbose=False

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -158,8 +158,8 @@ class InventoryFactory(object):
         
         
     def importObjs(self, objlist, obj_attr_dict,update=True,envar=None):
-        print("importing \"%s\" type:"%(self.objtype),file=sys.stderr)
-        print(" preprocessing \"%s\" type:"%(self.objtype),file=sys.stderr)
+        print("start to import \"%s\" type objects"%(self.objtype),file=sys.stderr)
+        print(" preprocessing \"%s\" type objects"%(self.objtype),file=sys.stderr)
         myclass = InventoryFactory.__InventoryClass__[self.objtype]
         myclass.loadschema(self.schemapath)
         myclass.validate_schema_version(None,'import')
@@ -167,7 +167,7 @@ class InventoryFactory(object):
         objfiles={}
         exptmsglist=[]
         for key, attrs in obj_attr_dict.items():
-            print("  converting object \"%s\" to table entries"%(key),file=sys.stderr)
+            verbose("  converting object \"%s\" to table entries"%(key),file=sys.stderr)
             if not objlist or key in objlist:
                 if 'OBJNAME' in envar.keys():
                     envar['OBJNAME']=key
@@ -189,7 +189,7 @@ class InventoryFactory(object):
         if not update:
             self.getDBInst().cleartab(tabs)
         if dbdict:
-            print(" writting \"%s\" type:"%(self.objtype),file=sys.stderr)
+            print(" writting \"%s\" type objects"%(self.objtype),file=sys.stderr)
             self.getDBInst().settab(dbdict)
         return objfiles
 

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -439,6 +439,7 @@ def importfromfile(objtypelist, objlist, location,dryrun=None,version=None,updat
     envar=vardict
     if dbsession is None: 
         dbsession=DBsession()
+    print("loading inventory date in \"%s\""%(location),file=sys.stderr)
     try:
         obj_attr_dict = json.loads(contents)
     except ValueError:

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -13,9 +13,13 @@ from exceptions import *
 from utils import *
 import globalvars
 import os
-import yaml
 import shutil
 from jinja2 import Template,Environment,meta,FileSystemLoader
+import yaml
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
 
 """
 Command-line interface to xCAT inventory import/export
@@ -444,7 +448,7 @@ def importfromfile(objtypelist, objlist, location,dryrun=None,version=None,updat
         obj_attr_dict = json.loads(contents)
     except ValueError:
         try: 
-            obj_attr_dict = yaml.load(contents)
+            obj_attr_dict = yaml.load(contents,Loader=Loader)
         except Exception,e:
             raise InvalidFileException("Error: failed to load file \"%s\", please validate the file with 'yamllint %s'(for yaml format) or 'cat %s|python -mjson.tool'(for json format)!"%(location,location,location))
   

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -158,6 +158,8 @@ class InventoryFactory(object):
         
         
     def importObjs(self, objlist, obj_attr_dict,update=True,envar=None):
+        print("importing \"%s\" type:"%(self.objtype),file=sys.stderr)
+        print(" preprocessing \"%s\" type:"%(self.objtype),file=sys.stderr)
         myclass = InventoryFactory.__InventoryClass__[self.objtype]
         myclass.loadschema(self.schemapath)
         myclass.validate_schema_version(None,'import')
@@ -165,6 +167,7 @@ class InventoryFactory(object):
         objfiles={}
         exptmsglist=[]
         for key, attrs in obj_attr_dict.items():
+            print("  converting object \"%s\" to table entries"%(key),file=sys.stderr)
             if not objlist or key in objlist:
                 if 'OBJNAME' in envar.keys():
                     envar['OBJNAME']=key
@@ -186,6 +189,7 @@ class InventoryFactory(object):
         if not update:
             self.getDBInst().cleartab(tabs)
         if dbdict:
+            print(" writting \"%s\" type:"%(self.objtype),file=sys.stderr)
             self.getDBInst().settab(dbdict)
         return objfiles
 
@@ -319,7 +323,7 @@ def export_by_type(objtype, names, destfile=None, destdir=None, fmt='yaml',versi
         if nonexistobjlist:
             raise ObjNonExistException("Error: cannot find "+myobjtype+" objects: %(f)s!", f=','.join(nonexistobjlist))
         if destdir and myobjtype in InventoryFactory.getObjTypesWithFiles():
-            print("The %s objects has been exported to directory %s"%(myobjtype,destdir))
+            print("The %s objects has been exported to directory %s"%(myobjtype,destdir),file=sys.stderr)
 
         #do not add osimage objects to %wholedict when export inventory data to a directory
         if not destdir or myobjtype not in InventoryFactory.getObjTypesWithFiles():
@@ -341,12 +345,12 @@ def export_by_type(objtype, names, destfile=None, destdir=None, fmt='yaml',versi
             dumpobj(wholedict, fmt,mylocation)
             with open(mylocation, "a") as myfile:
                 myfile.write("#%s"%(xcatversion))
-            print("The cluster inventory data has been dumped to %s"%(mylocation))
+            print("The cluster inventory data has been dumped to %s"%(mylocation),file=sys.stderr)
         elif destfile:
             dumpobj(wholedict, fmt,destfile)
             with open(destfile, "a") as myfile:
                 myfile.write("#%s"%(xcatversion))
-            print("The inventory data has been dumped to %s"%(destfile))
+            print("The inventory data has been dumped to %s"%(destfile),file=sys.stderr)
         else: 
             if not fmt or fmt.lower() == 'yaml':
                 dump2yaml(wholedict)
@@ -494,9 +498,9 @@ def importfromfile(objtypelist, objlist, location,dryrun=None,version=None,updat
         except Exception, e: 
             raise DBException("Error on commit DB transactions: "+str(e))
         else:
-            print('Inventory import successfully!')
+            print('Inventory import successfully!',file=sys.stderr)
     else:
-        print("Dry run mode, nothing will be written to database!")
+        print("Dry run mode, nothing will be written to database!",file=sys.stderr)
     dbsession.close()
     return objfiledict
 
@@ -525,7 +529,7 @@ def importobjdir(location,dryrun=None,version=None,update=True,dbsession=None,en
         srcfile=location+myfile
         if os.path.exists(srcfile):
             if dryrun:
-                print("creating directory: %s. Dryrun mode, do nothing..."%(os.path.dirname(myfile)))
+                print("creating directory: %s. Dryrun mode, do nothing..."%(os.path.dirname(myfile)),file=sys.stderr)
             else:
                 try:
                     os.makedirs(os.path.dirname(myfile))
@@ -539,12 +543,12 @@ def importobjdir(location,dryrun=None,version=None,update=True,dbsession=None,en
                 print("Warning: \"%s\" and \"%s\" are the same file, skip copy"%(srcfile,myfile),file=sys.stderr)
             else:
                 if dryrun:
-                    print("copying file: %s ----> %s. Dryrun mode, do nothing..."%(srcfile,myfile))
+                    print("copying file: %s ----> %s. Dryrun mode, do nothing..."%(srcfile,myfile),file=sys.stderr)
                 else:
                     shutil.copyfile(srcfile,myfile)
         else:
             print("Warning: the file \""+srcfile+"\" of "+objtype+" \""+objname+"\" does not exist!",file=sys.stderr)
-    print("The object "+objname+" has been imported")
+    print("The object "+objname+" has been imported",file=sys.stderr)
 
 def importfromdir(location,objtype='osimage',objnamelist=None,dryrun=None,version=None,update=True,dbsession=None,envs=None):
     importall=0

--- a/xcat-inventory/xcclient/inventory/utils.py
+++ b/xcat-inventory/xcclient/inventory/utils.py
@@ -132,3 +132,8 @@ def filter_dict_keys(d1, d2):
             if subkey not in d2[key]:
                 del tmp_d1[key][subkey]
     return tmp_d1
+
+#print if -v|--verbose specified
+def verbose(message,file=sys.stdout):
+    if globalvars.verbose:
+        print("%s"%(message),file=file)

--- a/xcat-inventory/xcclient/inventory/utils.py
+++ b/xcat-inventory/xcclient/inventory/utils.py
@@ -5,6 +5,7 @@
 # -*- coding: utf-8 -*-
 # common helper subroutines
 #
+from __future__ import print_function
 import os
 import re
 import subprocess

--- a/xcat-inventory/xcclient/shell.py
+++ b/xcat-inventory/xcclient/shell.py
@@ -11,13 +11,13 @@ Command-line interface skeleton to xCAT
 """
 
 from __future__ import print_function
-
 import argparse
 import logging
 import os
 import sys
 import six
 import inventory.exceptions 
+import inventory.globalvars
 
 # Decorator to define CLI args
 def arg(*args, **kwargs):
@@ -57,7 +57,7 @@ class ClusterShell(object):
         parser.add_argument('-v', '--verbose',
                             default=False,
                             action='store_true',
-                            help="Prints verbose output (not implemented yet).")
+                            help="Prints verbose output.")
 
         parser.add_argument('-V', '--version',
                             action='version',
@@ -80,6 +80,7 @@ class ClusterShell(object):
 
     def add_subcommands(self, parser):
         # Add the subparsers for each CLI
+        
 
         #self._find_actions(subparsers, actions_module)
         raise NotImplementedError()
@@ -158,6 +159,7 @@ class ClusterShell(object):
         # Parse args once to find version
         parser = self.get_common_parser(description)
         (options, args) = parser.parse_known_args(argv)
+        inventory.globalvars.verbose=options.verbose     
         self.setup_debugging(options.debug)
 
         # build available subcommands based on version
@@ -169,7 +171,7 @@ class ClusterShell(object):
         if not argv:
             self.do_help(options)
             return 0
-
+        
         if not args:
             self.do_help(options)
             return 0
@@ -179,7 +181,7 @@ class ClusterShell(object):
             raise inventory.exceptions.CommandException("Error: not a valid subcommand to run")
 
         # Parse args again and call whatever callback was selected
-        args = subcommand_parser.parse_args(argv)
+        args = subcommand_parser.parse_args(args)
 
         # Short-circuit and deal with help command right away.
         if args.func == self.do_help:


### PR DESCRIPTION
* add more verbose info
* use "CLOADER" to accelerate yaml.load

fix #117 :

UT:
```
[root@c910f03c05k21 inventory]# xcat-inventory   import -f /tmp/cluster -t policy -v
start to import "policy" type objects
 preprocessing "policy" type objects
  converting object "1.2" to table entries
  converting object "7.2" to table entries
  converting object "7.3" to table entries
  converting object "7.1" to table entries
  converting object "7.6" to table entries
  converting object "7.4" to table entries
  converting object "2.3" to table entries
  converting object "2.1" to table entries
  converting object "4.5" to table entries
  converting object "4.4" to table entries
  converting object "4.7" to table entries
  converting object "4.6" to table entries
  converting object "4.9" to table entries
  converting object "4.8" to table entries
  converting object "1" to table entries
  converting object "3" to table entries
  converting object "2" to table entries
  converting object "4" to table entries
 writting "policy" type objects
  writting object: 4.5
  writting object: 4.4
  writting object: 4.7
  writting object: 4.6
  writting object: 1.2
  writting object: 7.2
  writting object: 4.9
  writting object: 4.8
  writting object: 1
  writting object: 7.3
  writting object: 3
  writting object: 7.1
  writting object: 7.6
  writting object: 4
  writting object: 7.4
  writting object: 2.3
  writting object: 2
  writting object: 2.1
Inventory import successfully!
You have new mail in /var/spool/mail/root
[root@c910f03c05k21 inventory]# xcat-inventory   import -f /tmp/cluster -t policy
start to import "policy" type objects
 preprocessing "policy" type objects
 writting "policy" type objects
Inventory import successfully!
```