### PR TITLE
avoid exception during import file with relative path

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -377,7 +377,7 @@ def getgitinfo(location):
     #vardict['GITROOT']=''
     vardict={}
     oldcwd=os.getcwd()
-    os.chdir(os.path.dirname(location))
+    os.chdir(os.path.dirname(os.path.realpath(location)))
     (retcode,out,err)=runCommand("git rev-parse --show-toplevel")
     if retcode==0:
         out=out.strip()


### PR DESCRIPTION
UT:

```
[root@c910f03c05k21 tmp]# ls
cluster           systemd-private-d61d1421350f44f7988d0e2f0a49377e-httpd.service-DK8RoT    wget-1.12-1.8.el6.ppc64.rpm
inventorydiff.py  systemd-private-d61d1421350f44f7988d0e2f0a49377e-mariadb.service-OchVce  wget-1.14-4.83.ppc64le.rpm
nodes             systemd-private-d61d1421350f44f7988d0e2f0a49377e-named.service-N0GlIf    xcat
snap              systemd-private-d61d1421350f44f7988d0e2f0a49377e-ntpd.service-joBoC3
structurediff.py  wget
[root@c910f03c05k21 tmp]# xcat-inventory import -f cluster
loading inventory date in "cluster"
start to import "node" type objects
 preprocessing "node" type objects
 writting "node" type objects
```