### PR TITLE
fix issue 129, print out help msg when run xcat-inventory export -h

### DIFF
--- a/xcat-inventory/xcclient/shell.py
+++ b/xcat-inventory/xcclient/shell.py
@@ -171,7 +171,7 @@ class ClusterShell(object):
         if not argv:
             self.do_help(options)
             return 0
-        
+
         if not args:
             self.do_help(options)
             return 0
@@ -179,6 +179,9 @@ class ClusterShell(object):
         if args[0] not in self.subcommands.keys():
             self.do_help(options)
             raise inventory.exceptions.CommandException("Error: not a valid subcommand to run")
+
+        if '-h' in argv or '--help' in argv:
+            args.append('-h')
 
         # Parse args again and call whatever callback was selected
         args = subcommand_parser.parse_args(args)


### PR DESCRIPTION
#129 

In pull request #118, modified to pass ``args`` to ``subcommand_parser.parse_args`` not ``argv``(include all options). So if ``'-h' or '--help'`` in argv, append to args.

UT:
```
# xcat-inventory export --help
usage: xcat-inventory export [-t <type>] [-x EXCLUDE] [-o <name>] [-f <path>]
                             [-d <directory>] [-s <version>]
                             [--format <format>]

Export the inventory data from xcat database

Arguments:
  -t <type>, --type <type>
                        comma "," delimited types of objects to export, valid
                        values: node,passwd,osimage,network,zone,credential,po
                        licy,route,site. If not specified, all objects in xcat
                        databse will be exported
  -x EXCLUDE, --exclude EXCLUDE
                        types to be excluded when exporting all, delimited
                        with Comma(,).
  -o <name>, --objects <name>
                        names of the objects to export, delimited with
                        Comma(,). If not specified, all objects of the
                        specified type will be exported
  -f <path>, --path <path>
                        path of the inventory file
  -d <directory>, --dir <directory>
                        path of the inventory directory
  -s <version>, --schema-version <version>
                        schema version of the inventory data. Valid values:
                        latest,1.0. If not specified, the "latest" schema
                        version will be used
  --format <format>     format of the inventory data, valid values: json,
                        yaml. yaml will be used by default if not specified


# xcat-inventory export -h
usage: xcat-inventory export [-t <type>] [-x EXCLUDE] [-o <name>] [-f <path>]
                             [-d <directory>] [-s <version>]
                             [--format <format>]

Export the inventory data from xcat database

Arguments:
  -t <type>, --type <type>
                        comma "," delimited types of objects to export, valid
                        values: node,passwd,osimage,network,zone,credential,po
                        licy,route,site. If not specified, all objects in xcat
                        databse will be exported
  -x EXCLUDE, --exclude EXCLUDE
                        types to be excluded when exporting all, delimited
                        with Comma(,).
  -o <name>, --objects <name>
                        names of the objects to export, delimited with
                        Comma(,). If not specified, all objects of the
                        specified type will be exported
  -f <path>, --path <path>
                        path of the inventory file
  -d <directory>, --dir <directory>
                        path of the inventory directory
  -s <version>, --schema-version <version>
                        schema version of the inventory data. Valid values:
                        latest,1.0. If not specified, the "latest" schema
                        version will be used
  --format <format>     format of the inventory data, valid values: json,
                        yaml. yaml will be used by default if not specified
```