### PR TITLE
fix xcat-inventory --version print #VERSION_SUBSTITUTE#

### DIFF
--- a/build-ubuntu
+++ b/build-ubuntu
@@ -50,6 +50,13 @@ if [ ! -z ${LOG} ]; then
     WGET_CMD="wget -o ${LOG}"
 fi
 
+VERSION=$(git describe --long --tags|cut -d- -f 1 | tail -c +2)
+NUMCOMMITS=$(git describe --long --tags|cut -d- -f 2)
+if [ "$NUMCOMMITS" != "$VERSION"  ]; then
+    VERSION=$VERSION
+fi
+echo $VERSION > Version
+
 if [ "$c_flag" ]
 then
     if [ -z "$REL" ]; then
@@ -59,25 +66,17 @@ then
 
     if [ "$PROMOTE" != 1 ]; then
 
-        code_change=1
-        ver=`cat Version`
-        short_ver=`cat Version|cut -d. -f 1,2`
-        short_short_ver=`cat Version|cut -d. -f 1`
-        build_time=`date`
         build_machine=`hostname`
-        commit_id=`git rev-parse --short HEAD`
         commit_id_long=`git rev-parse HEAD`
 
         echo "###################################"
         echo "# Building xcat-inventory package #"
         echo "###################################"
 
-        #the package type:  local | snap | alpha
         #the build introduce string
-        build_string="Snap_Build"
-        xcat_release="snap$(date '+%Y%m%d%H%M')"
-        pkg_version="${ver}-${xcat_release}"
-        VERINFO="${ver} (${xcat_release})"
+        build_string="xcat-inventory Build"
+        pkg_version="${VERSION}-c${NUMCOMMITS}"
+        VERINFO="${VERSION} (git commit $commit_id_long)"
         echo "VERINFO $VERINFO"
         packages="xcat-inventory"
         cp -f $curdir/xcat-inventory/xcclient/inventory/shell.py /tmp/
@@ -94,11 +93,7 @@ then
                 dch -v $pkg_version -b -c debian/changelog $build_string
                 if [ "$target_arch" = "all" ]; then
                     CURDIR=$(pwd)
-                    cp ${CURDIR}/debian/control ${CURDIR}/debian/control.save.998
-                    # Magic string used here
-                    sed -i -e "s#>= 2.13-snap000000000000#= ${pkg_version}#g" ${CURDIR}/debian/control
                     dpkg-buildpackage -rfakeroot -uc -us
-                    mv ${CURDIR}/debian/control.save.998 ${CURDIR}/debian/control
                     dh_testdir
                     dh_testroot
                     dh_clean -d
@@ -109,7 +104,7 @@ then
                     exit $rc
                 fi
                 rm -f debian/files
-                sed -i -e "s/* Snap_Build//g" debian/changelog
+                sed -i -e "s/* Build//g" debian/changelog
                 cd -
                 rm -f ${file_low}_*.tar.gz
                 rm -f ${file_low}_*.changes

--- a/build-ubuntu
+++ b/build-ubuntu
@@ -68,17 +68,20 @@ then
         commit_id=`git rev-parse --short HEAD`
         commit_id_long=`git rev-parse HEAD`
 
-        echo "###############################"
+        echo "###################################"
         echo "# Building xcat-inventory package #"
-        echo "###############################"
+        echo "###################################"
 
         #the package type:  local | snap | alpha
         #the build introduce string
         build_string="Snap_Build"
         xcat_release="snap$(date '+%Y%m%d%H%M')"
         pkg_version="${ver}-${xcat_release}"
-
+        VERINFO="${ver} (${xcat_release})"
+        echo "VERINFO $VERINFO"
         packages="xcat-inventory"
+        cp -f $curdir/xcat-inventory/xcclient/inventory/shell.py /tmp/
+        sed -i s/\#VERSION_SUBSTITUTE\#/"$VERINFO"/g $curdir/xcat-inventory/xcclient/inventory/shell.py
         target_archs=(all)
         for file in $packages
         do
@@ -113,7 +116,10 @@ then
                 rm -f ${file_low}_*.dsc
             done
         done
-
+        if [ -f /tmp/shell.py ]; then
+            cp -f /tmp/shell.py $curdir/xcat-inventory/xcclient/inventory/shell.py
+            rm -f /tmp/shell.py
+        fi
     fi
 
 fi


### PR DESCRIPTION
fix xcat-inventory --version print #VERSION_SUBSTITUTE# for https://github.com/xcat2/xcat-inventory/issues/133

UT:
```
# ./build-ubuntu -c xcat-inventory
###################################
# Building xcat-inventory package #
###################################
###################################
# Building xcat-inventory package #
###################################
VERINFO 0.1.5 (git commit 7ae3b70d6f4039f83870766d94d9ee574b58ce76)
dpkg-buildpackage: warning: using a gain-root-command while being root
dpkg-buildpackage: source package xcat-inventory
dpkg-buildpackage: source version 0.1.5-c21
dpkg-buildpackage: source distribution UNRELEASED
... ...
dpkg-deb: building package 'xcat-inventory' in '../xcat-inventory_0.1.5-c21_all.deb'.
pwd
/root/baiyuan/xcat-inventory/xcat-inventory
 dpkg-genchanges  >../xcat-inventory_0.1.5-c21_ppc64el.changes
dpkg-genchanges: warning: the current version (0.1.5-c21) is earlier than the previous one (2.9.13-1)
dpkg-genchanges: including full source code in upload
 dpkg-source --after-build xcat-inventory
dpkg-buildpackage: full upload; Debian-native package (full source is included)
/root/baiyuan/xcat-inventory

# dpkg -i xcat-inventory_0.1.5-c21_all.deb
(Reading database ... 108222 files and directories currently installed.)
Preparing to unpack xcat-inventory_0.1.5-c21_all.deb ...
Unpacking xcat-inventory (0.1.5-c21) over (0.1.5-c21) ...
Setting up xcat-inventory (0.1.5-c21) ...

# dpkg -l |grep xcat-inventory
ii  xcat-inventory                       0.1.5-c21                                  all          xcat inventory

# xcat-inventory --version
0.1.5 (git commit 7ae3b70d6f4039f83870766d94d9ee574b58ce76)
```