### PR TITLE
xcat-inventory support multiple object passwd enhancement

### DIFF
--- a/xcat-inventory/xcclient/inventory/dbfactory.py
+++ b/xcat-inventory/xcclient/inventory/dbfactory.py
@@ -95,7 +95,11 @@ class matrixdbfactory():
                continue
            for myobj in tabobj:
                mydict=myobj.getdict()
-               mykey=mydict[tab.__tablename__+'.'+tabkey]
+               mysecondkey=myobj.getsecondkey()
+               if tab.__tablename__+'.'+tabkey in mydict.keys():
+                  mykey=mydict[tab.__tablename__+'.'+tabkey]
+               elif mysecondkey is not None:
+                  mykey=myobj.__dict__[tabkey]
                if mykey not in ret.keys():
                   ret[mykey]={}
                ret[mykey].update(mydict)

--- a/xcat-inventory/xcclient/inventory/dbobject.py
+++ b/xcat-inventory/xcclient/inventory/dbobject.py
@@ -7,9 +7,18 @@ import pdb
 class mixin(object):
     def getdict(self):
         mydict={}
+        mykeyvalue=''
         for mykey in self.__dict__.keys():
-           if mykey in self.__table__.columns:
-              mydict[self.__tablename__+'.'+mykey.encode()]= self.__dict__[mykey] if self.__dict__[mykey] is None else self.__dict__[mykey].encode()
+           if mykey in self.__table__.columns and mykey not in self.getkeys():
+               mydict[self.__tablename__+'.'+mykey.encode()]= self.__dict__[mykey] if self.__dict__[mykey] is None else self.__dict__[mykey].encode()
+        for mykey in self.getkeys():
+            if mykeyvalue is '':
+                mykeyvalue=self.__dict__[mykey] if self.__dict__[mykey] is None else self.__dict__[mykey].encode()
+            else:
+                mykeyvalue+='.'
+                mykeyvalue+=self.__dict__[mykey] if self.__dict__[mykey] is None else self.__dict__[mykey].encode()
+        mykeyvalue=mykeyvalue.rstrip('.')
+        mydict[self.__tablename__+'.'+self.getdictkey()]=mykeyvalue      
         try:
             self.__class__.outprocess(mydict)
         except:
@@ -17,7 +26,15 @@ class mixin(object):
         return mydict
 
     @classmethod
-    def getkey(cls):
+    def getkeys(cls):
+        ins = inspect(cls)
+        keys=[]
+        for item in ins.primary_key:
+            keys.append(item.key)
+        return keys            
+
+    @classmethod
+    def getdictkey(cls):
         ins = inspect(cls)
         return ins.primary_key[0].key
 
@@ -40,11 +57,6 @@ class mixin(object):
     @classmethod
     def getReservedKeys(self):
         return []
-    
-    @classmethod
-    def getsecondkey(self):
-        return ''
-
 ########################################################################
 class passwd(Base,mixin):
     """"""
@@ -52,21 +64,14 @@ class passwd(Base,mixin):
     __tablename__ = 'passwd'
     __table_args__ = {'autoload':True}
 
-    def getsecondkey(self):
-        return 'username'
+    @classmethod
+    def getdictkey(cls):
+        return 'key.username'
 
-    def getdict(self):
-        mydict={}
-        mydictvalue={}
-        for mykey in self.__dict__.keys():
-           if mykey in self.__table__.columns:
-              mydictvalue[self.__tablename__+'.'+mykey.encode()]= self.__dict__[mykey] if self.__dict__[mykey] is None else self.__dict__[mykey].encode()
-              mydict[self.__dict__['username'].encode()]= mydictvalue
-        try:
-            self.__class__.outprocess(mydict)
-        except:
-            pass
-        return mydict
+    @classmethod
+    def getkeys(cls):
+        return ['key','username']
+
 ########################################################################
 class networks(Base,mixin):
     """"""

--- a/xcat-inventory/xcclient/inventory/dbobject.py
+++ b/xcat-inventory/xcclient/inventory/dbobject.py
@@ -35,6 +35,7 @@ class mixin(object):
 
     @classmethod
     def getdictkey(cls):
+        """after DB table convert to dict, generate dictkey prepare for object dict"""
         ins = inspect(cls)
         return ins.primary_key[0].key
 
@@ -80,7 +81,7 @@ class networks(Base,mixin):
     __table_args__ = {'autoload':True}
 
     @classmethod
-    def getkey(cls):
+    def getdictkey(cls):
         return 'netname'
 
     @classmethod    
@@ -96,6 +97,10 @@ class networks(Base,mixin):
             return False
         else:
             return True
+
+    @classmethod
+    def getkeys(cls):
+        return ['netname']
 
 ########################################################################
 class routes(Base,mixin):
@@ -132,6 +137,15 @@ class switch(Base,mixin):
     Base.metadata.bind = DBsession.getEngine('switch')
     __tablename__ = 'switch'
     __table_args__ = {'autoload':True}
+
+    @classmethod
+    def getdictkey(cls):
+        return 'node'
+
+    @classmethod
+    def getkeys(cls):
+        return ['node']
+
 ########################################################################
 class switches(Base,mixin):
     """"""

--- a/xcat-inventory/xcclient/inventory/dbobject.py
+++ b/xcat-inventory/xcclient/inventory/dbobject.py
@@ -40,6 +40,11 @@ class mixin(object):
     @classmethod
     def getReservedKeys(self):
         return []
+    
+    @classmethod
+    def getsecondkey(self):
+        return ''
+
 ########################################################################
 class passwd(Base,mixin):
     """"""
@@ -47,6 +52,21 @@ class passwd(Base,mixin):
     __tablename__ = 'passwd'
     __table_args__ = {'autoload':True}
 
+    def getsecondkey(self):
+        return 'username'
+
+    def getdict(self):
+        mydict={}
+        mydictvalue={}
+        for mykey in self.__dict__.keys():
+           if mykey in self.__table__.columns:
+              mydictvalue[self.__tablename__+'.'+mykey.encode()]= self.__dict__[mykey] if self.__dict__[mykey] is None else self.__dict__[mykey].encode()
+              mydict[self.__dict__['username'].encode()]= mydictvalue
+        try:
+            self.__class__.outprocess(mydict)
+        except:
+            pass
+        return mydict
 ########################################################################
 class networks(Base,mixin):
     """"""

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -301,9 +301,8 @@ def export_by_type(objtype, names, destfile=None, destdir=None, fmt='yaml',versi
     else:
         objtypelist.extend(InventoryFactory.getvalidobjtypes())
         exportall=1
-
     if names:
-        objlist.extend([n.strip() for n in names.split(',')])
+        objlist.extend([n.strip() and n.rstrip('.') for n in names.split(',')])
 
     wholedict={} 
     for myobjtype in objtypelist:

--- a/xcat-inventory/xcclient/inventory/schema/0.1/passwd.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/0.1/passwd.yaml
@@ -1,6 +1,5 @@
 !!python/dict  
   passwd:
-    username: "T{passwd.username}"
     password: "T{passwd.password}"
     cryptmethod: 
     - "T{passwd.cryptmethod}"

--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -317,7 +317,7 @@ class XcatBase(object):
         if schema is None:
             schema=cls._schema_loc__
         #cls._schema=yaml.load(file(schema,'r'))['node']
-        try:
+        try: 
             schemacontent=yaml.load(file(schema,'r'))
         except Exception, e:
             raise BadSchemaException("Error: Invalid schema file \""+schema+"\"!") 
@@ -338,7 +338,7 @@ class XcatBase(object):
 
     def getobjdict(self):
         ret={}
-        ret[self.name.encode()]=deepcopy(self._mydict)
+        ret[self.name]=deepcopy(self._mydict)
         Util_rmnullindict(ret[self.name])
         del ret[self.name]['obj_name']
         return ret
@@ -561,48 +561,6 @@ class Policy(XcatBase):
 class Passwd(XcatBase):
     _schema_loc__ = os.path.join(os.path.dirname(__file__), 'schema/latest/passwd.yaml')
 
-    def setdbdata(self,dbhash):
-        self._dbhash=deepcopy(dbhash)
-        self._mydict.clear()
-        self._mydict['obj_name']=self.name
-        self.__db2dict()
-
-    def __db2dict(self):
-        for attr in self._dbhash.keys():
-            _dbhashvalue={}
-            for key in self._depdict_val.keys():
-                _dbhashvalue[key]=self.__evalschema_val(key,self._dbhash[attr])
-            Util_setdictval(self._mydict,attr,_dbhashvalue)
-
-    def __evalschema_val(self,valpath,dbhashvalue):
-        mydeptablist=self._depdict_val[valpath]['deptablist']
-        mydepvallist=self._depdict_val[valpath]['depvallist']
-        myexpression=self._depdict_val[valpath]['expression']
-        for item in mydeptablist:
-            tabval=''
-            if item in dbhashvalue.keys():
-                tabval=dbhashvalue[item]
-            if tabval is None:
-                tabval=''
-            myexpression=myexpression.replace('T{'+item+'}',"'"+str(tabval).replace("'","\\'")+"'")
-        ctxdict={}
-        for item in mydepvallist:
-            myval=Util_getdictval(self._mydict,item)
-            if myval is None:
-                myval=self.__evalschema_val(item)
-                if myval is None:
-                    myval=''
-            newitem=item.replace('.','_').replace('{','_').replace('}','_')
-            newitem="V_%s"%(newitem)
-            ctxdict[newitem]=myval
-            myexpression=myexpression.replace('V{'+item+'}',newitem)
-        try:
-            evalexp=eval("lambda "+myexpression,None,ctxdict)
-            value=evalexp()
-        except Exception,e:
-            raise  InvalidValueException("Error: failed to process schema entry ["+valpath+"]: \""+myexpression+"\": "+str(e))
-        return value
-  
 class Site(XcatBase):
     _schema_loc__ = os.path.join(os.path.dirname(__file__), 'schema/latest/site.yaml')
 


### PR DESCRIPTION
xcat-inventory import passwd object task: https://github.com/xcat2/xcat-inventory/issues/138
xcat-inventory export passwd object issue: https://github.com/xcat2/xcat-inventory/issues/86

This PR realized : xcat-inventory import and export passwd object with 2 keys

UT:
1. export all passwd objects:
```
# xcat-inventory export -t passwd
passwd:
  omapi.xcat_key:
    password: xxxxxx
  xcat:
    cryptmethod: md5
    password: '12345'
  xcat.root:
    cryptmethod: md5
    password: '9999'
  xcat.wsuser:
    cryptmethod: md5
    password: '8888'
schema_version: '1.0'

#Version 2.14.4 (git commit 819b20b6602035d530c5d38afe6c79697151de20, built Fri Sep 21 06:17:52 EDT 2018)
```

2. export 'xcat.root' and 'xcat' objects
```
]# xcat-inventory export -t passwd -o xcat,xcat.root
passwd:
  xcat:
    cryptmethod: md5
    password: '12345'
  xcat.root:
    cryptmethod: md5
    password: '9999'
schema_version: '1.0'

#Version 2.14.4 (git commit 819b20b6602035d530c5d38afe6c79697151de20, built Fri Sep 21 06:17:52 EDT 2018)
```

3. export invalid object:
```
]# xcat-inventory export -t passwd -o xxxx
Error: cannot find passwd objects: xxxx!
```

4. export other object:
```
]# xcat-inventory export -t node -o test1
node:
  test1:
    device_type: switch
    obj_info:
      groups: all,test
    obj_type: node
    role: service
schema_version: '1.0'

#Version 2.14.4 (git commit 819b20b6602035d530c5d38afe6c79697151de20, built Fri Sep 21 06:17:52 EDT 2018)

]# xcat-inventory export -t site
schema_version: '1.0'
site:
  clustersite:
    SNsyncfiledir: /var/xcat/syncfiles
    auditnosyslog: '0'
    auditskipcmds: ALL
    blademaxp: '64'
    cleanupxcatpost: 'no'
    consoleondemand: 'no'
    databaseloc: /var/lib
    db2installloc: /mntdb2
    dhcplease: '43200'
    dnshandler: ddns
    domain: cluster.com
    enableASMI: 'no'
    forwarders: 10.5.106.2
    fsptimeout: '0'
    installdir: /install
    ipmimaxp: '64'
    ipmiretries: '3'
    ipmitimeout: '2'
    master: 10.5.106.7
    maxssh: '8'
    nameservers: 10.5.106.7
    nodesyncfiledir: /var/xcat/node/syncfiles
    powerinterval: '0'
    ppcmaxp: '64'
    ppcretry: '3'
    ppctimeout: '0'
    sharedtftp: '1'
    sshbetweennodes: ALLGROUPS
    syspowerinterval: '0'
    tftpdir: /tftpboot
    timezone: America/New_York
    useNmapfromMN: 'no'
    vsftp: n
    xcatconfdir: /etc/xcat
    xcatdport: '3001'
    xcatiport: '3002'
    xcatsslversion: TLSv1

#Version 2.14.4 (git commit 819b20b6602035d530c5d38afe6c79697151de20, built Fri Sep 21 06:17:52 EDT 2018)
```

5. import passwd objects:
```
[root@bybc0607 inventory]# cat /root/test
passwd:
  bai:
    cryptmethod: md5
    password: '666'
  bai.root:
    cryptmethod: md5
    password: '777'
schema_version: '1.0'

#Version 2.14.4 (git commit 819b20b6602035d530c5d38afe6c79697151de20, built Fri Sep 21 06:17:52 EDT 2018)
[root@bybc0607 inventory]# xcat-inventory import -f /root/test
loading inventory date in "/root/test"
start to import "passwd" type objects
 preprocessing "passwd" type objects
 writting "passwd" type objects
Inventory import successfully!
[root@bybc0607 inventory]# tabdump passwd
#key,username,password,cryptmethod,authdomain,comments,disable
"xcat",,"12345","md5",,,
"xcat","wsuser","8888","md5",,,
"omapi","xcat_key","xxxxxx",,,,
"xcat","root","9999","md5",,,
"bai","root","777","md5",,,
"bai",,"666","md5",,,
```

6. after clean up passwd table, import `/root/test`
```
[root@bybc0607 inventory]# xcat-inventory import -f /root/test -c
loading inventory date in "/root/test"
start to import "passwd" type objects
 preprocessing "passwd" type objects
 writting "passwd" type objects
Inventory import successfully!
[root@bybc0607 inventory]# tabdump passwd
#key,username,password,cryptmethod,authdomain,comments,disable
"bai","root","777","md5",,,
"bai",,"666","md5",,,
```

7. import node:
```
[root@bybc0607 inventory]# cat /root/test1
node:
  test2:
    device_type: server
    obj_info:
      groups: all,test
    obj_type: node
    role: compute
schema_version: '1.0'

[root@bybc0607 inventory]# xcat-inventory import -f /root/test1 -c
loading inventory date in "/root/test1"
start to import "node" type objects
 preprocessing "node" type objects
 writting "node" type objects
Inventory import successfully!
[root@bybc0607 inventory]# nodels
test2
[root@bybc0607 inventory]# lsdef test2
Object name: test2
    groups=all,test
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles
```

