### PR TITLE
fix unknown encoding utf8mb4

### DIFF
--- a/xcat-inventory/xcclient/inventory/dbsession.py
+++ b/xcat-inventory/xcclient/inventory/dbsession.py
@@ -12,7 +12,9 @@ import re
 import os
 import sqlalchemy.exc
 from exceptions import *
+import codecs
 
+codecs.register(lambda name: codecs.lookup('utf8') if name == 'utf8mb4' else None)
 
 Base = declarative_base()
 Base.metadata.bind = None;


### PR DESCRIPTION
for https://github.com/xcat2/xcat-inventory/issues/143

Description:
make python understand 'utf8mb4' as an alias for 'utf8'

UT:
```
[root@c910f04x12v02 inventory]# xcat-inventory -V
0.1.5 (git commit 6301c1213c88cdfb2221cfe34af4d0ee1d83129a)
```