### PR TITLE
support prodkey as a subobject for node

### DIFF
--- a/xcat-inventory/xcclient/inventory/dbobject.py
+++ b/xcat-inventory/xcclient/inventory/dbobject.py
@@ -236,6 +236,10 @@ class prodkey(Base,mixin):
     Base.metadata.bind = DBsession.getEngine('prodkey')
     __tablename__ = 'prodkey'
     __table_args__ = {'autoload':True}
+
+    @classmethod
+    def getobjkey(cls):
+        return tuple(['node'])
 ########################################################################
 class domain(Base,mixin):
     """"""

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -29,9 +29,9 @@ VALID_OBJ_FORMAT = ['yaml', 'json']
 
 class InventoryFactory(object):
     __InventoryHandlers__ = {}
-    __InventoryClass__ = {'node': Node, 'network': Network, 'osimage': Osimage, 'route': Route, 'policy': Policy, 'passwd': Passwd,'site': Site,'zone':Zone,'credential':Credential,'networkconn':NetworkConn}
+    __InventoryClass__ = {'node': Node, 'network': Network, 'osimage': Osimage, 'route': Route, 'policy': Policy, 'passwd': Passwd,'site': Site,'zone':Zone,'credential':Credential,'networkconn':NetworkConn,'prodkey':ProductKey}
     __InventoryClass_WithFiles__=['osimage','credential']
-    __InventoryClass_partial__=['networkconn']
+    __InventoryClass_partial__=['networkconn','prodkey']
     __db__ = None
     
     def __init__(self, objtype,dbsession,schemapath,schemaversion):

--- a/xcat-inventory/xcclient/inventory/schema/2.0/node.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/2.0/node.yaml
@@ -81,8 +81,7 @@
         - "T{switches.protocol}"
         - "C:${{protocol=V{security_info.remotecontrol.remoteprotocol}: True if str(protocol) in ('','ssh','telnet') else False}}"
       zonename: "T{nodelist.zonename}"
-      product: "T{prodkey.product}"
-      productkey: "T{prodkey.key}"
+      productkey: "REF{prodkey}" 
     network_info:
       linkports: "${{devtype=V{device_type}: T{switches.linkports} if devtype == 'switch' else None}}"
       otherinterfaces: "T{hosts.otherinterfaces}"

--- a/xcat-inventory/xcclient/inventory/schema/2.0/prodkey.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/2.0/prodkey.yaml
@@ -1,0 +1,4 @@
+!!python/dict
+  productkey:
+    product: "T{prodkey.product}"
+    key: "T{prodkey.key}"

--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -600,5 +600,9 @@ class Credential(XcatBase):
 
 class NetworkConn(XcatBase):
     _schema_loc__ = os.path.join(os.path.dirname(__file__), 'schema/latest/networkconn.yaml')
+
+class ProductKey(XcatBase):
+    _schema_loc__ = os.path.join(os.path.dirname(__file__), 'schema/latest/prodkey.yaml')
+
 if __name__ == "__main__":
     pass


### PR DESCRIPTION
fix https://github.com/xcat2/xcat-inventory/issues/152

currently, the `prodkey` is a table with multiple primary keys, refine the schema of node object to include     `security_info:productkey` as a subject of  `prodkey`

UT:
```
[root@c910f03c01p13 inventory]# tabdump prodkey
#node,product,key,comments,disable
"bogusnode","os","productkey",,
"bogusnode","product1","productkey",,
[root@c910f03c01p13 inventory]# xcat-inventory export -t node -o bogusnode
node:
  bogusnode:
    deprecated:
      cfgmgtcfgmgr: cfgmgr
      cfgmgtcfgserver: cfgserver
      cfgmgtroles: cfgmgtroles
      chainondiscover: ondiscover
      hypervisorcluster: hostcluster
      hypervisorinterface: hostinterface
      hypervisormgr: hostmanager
      hypervisortype: hosttype
      iscsipasswd: iscsipassword
      iscsiserver: iscsiserver
      iscsitarget: iscsitarget
      iscsiuserid: iscsiuserid
      macinterface: interface
      nodehmcmdmapping: cmdmapping
      nodehmgetmac: getmac
      nodelisthidden: hidden
      noderesnfsdir: nfsdir
      noderesnimserver: nimserver
      noderesprimarynic: primarynic
      noderesproxydhcp: supportproxydhcp
      servicenodeftpserver: setupftp
      servicenodenimserver: setupnim
      storagecontroller: storagcontroller
      storageosvolume: osvolume
      storagetype: storagetype
      tftpdir: tftpdir
      vmmigrationdest: migrationdest
      vmtextconsole: vmtextconsole
      vpdside: side
    device_info:
      arch: ppc64
      characteristics: ppc,osi
      cpucount: cpucount
      cputype: cputype
      disksize: disksize
      memory: memory
      mtm: mtm
      serial: serial
      supportedarchs: supportedarchs
    device_type: hmc
    domain_info:
      adminpassword: domainadminpassword
      adminuser: domainadminuser
      authdomain: authdomain
      ou: ou
      type: domaintype
    engines:
      console_engine:
        engine_info:
          conserver: conserver
          consoleondemand: consoleondemand
          serialflow: serialflow
          serialport: serialport
          serialspeed: serialspeed
          terminalport: termport
          terminalserver: termserver
        engine_type: cons
      hardware_mgt_engine:
        engine_info:
          hcp: HMC
          hwtype: hwtype
          id: '5'
          mpa: mpa
          parent: parent
          pprofile: pprofile
          sfp: sfp
          supernode: supernode
          vmbeacon: vmbeacon
          vmbootorder: vmbootorder
          vmcfgstore: vmcfgstore
          vmcluster: vmcluster
          vmmanager: vmmanager
          vmmaster: vmmaster
          vmnicnicmodel: vmnicnicmodel
          vmphyslots: vmphyslots
          vmstorage: vmstorage
          vmstoragecache: vmstoragecache
          vmstorageformat: vmstorageformat
          vmstoragemodel: vmstoragemodel
          vmtextconsole: vmstorageformat
          vmvirtflags: vmvirtflags
          vmvncport: vmvncport
        engine_type: hmc
      netboot_engine:
        engine_info:
          addkcmdline: addkcmdline
          chain: chain
          installnic: installnic
          osimage: provmethod
          postbootscripts: postbootscripts
          postscripts: postscripts
          prescriptsbegin: prescripts-begin
          prescriptsend: prescripts-end
        engine_type: grub2
      power_mgt_engine:
        engine_info:
          pdu: pdu
        engine_type: power
    network_info:
      connections:
        interface: switchinterface
        switch: switch
        switchport: '50'
        vlan: switchvlan
      nics:
        bond0:
          nicdevices:
          - eth0
          - eth2
        br0:
          nicdevices:
          - bond0
        enP3p3s0f1:
          nicsinfo:
          - mac=98:be:94:59:fa:cd linkstate=DOWN
        enP3p3s0f2:
          nicsinfo:
          - mac=98:be:94:59:fa:ce candidatename=enP3p3s0f2/enx98be9459face
        enP48p1s0f0:
          ips:
          - 129.40.234.11
          networks:
          - pub_yellow
          type:
          - Ethernet
        enP48p1s0f1:
          networks:
          - xcat_util
          type:
          - unused
        enP5p1s0f1:
          networks:
          - xcat_compute
          type:
          - unused
        enP5p1s0f1.4:
          networks:
          - xcat_bmc
          type:
          - unused
        enP5p1s0f1.5:
          networks:
          - xcat_infra
          type:
          - unused
        enP5p1s0f1.6:
          networks:
          - xcat_pdu
          type:
          - unused
        eth0:
          alias:
          - moe larry curly
          configscripts:
          - configeth eth0
          extraconfig:
          - MTU=1500
          hostnameprefixe:
          - eth0-
          hostnamesuffixes:
          - -eth0
        eth1:
          alias:
          - tom
          - jerry
        ib0:
          configscripts:
          - configib ib0
          extraconfig:
          - MTU=65520 CONNECTED_MODE=yes
          hostnameprefixe:
          - ib-
          hostnamesuffixes:
          - -ib0
          ips:
          - 10.10.100.9
          networks:
          - IB00
          type:
          - Infiniband
        ib1:
          ips:
          - 10.11.100.9
          networks:
          - IB01
          type:
          - Infiniband
        ib2:
          networks:
          - IB02
          type:
          - unused
        ib3:
          networks:
          - IB03
          type:
          - unused
      otherinterfaces: otherinterfaces
      primarynic:
        hostnames: hostnames
        ip: 10.10.10.10
        mac:
        - 42:d6:0a:03:05:08
      routenames: routenames
    obj_info:
      description: usercomment
      groups: bogusgroup
    obj_type: node
    position_info:
      chassis: chassis
      height: height
      rack: rack
      room: room
      slot: slot
      unit: unit
    role: service
    role_info:
      dhcpinterfaces: dhcpinterfaces
      enablesyslog: syslog
      monserver: monserver
      nameservers: nameservers
      nfsserver: nfsserver
      nodelistprimarysn: primarysn
      servicenode: servicenode
      setupconserver: '0'
      setupdhcp: '0'
      setupipforward: '0'
      setupldap: '0'
      setupnameserver: '0'
      setupnfs: '0'
      setupntp: '0'
      setupproxydhcp: '0'
      setuptftp: '0'
      tftpserver: tftpserver
      xcatmaster: xcatmaster
    security_info:
      productkey:
      - key: productkey
        product: os
      - key: productkey
        product: product1
      remotecontrol:
        password: password
        username: username
      zonename: zonename
schema_version: '2.0'

#Version 2.14.5 (git commit 4042193c2100b874d58c9e85c7d35ad9bbd8f135, built Mon Nov  5 06:16:43 EST 2018)
[root@c910f03c01p13 inventory]#
```