### PR TITLE
fix rpm  build issue

### DIFF
--- a/makepythonrpm
+++ b/makepythonrpm
@@ -9,6 +9,7 @@ function makepythoncli {
     RPMNAME="$1"
     SPEC_FILE="xcat-inventory.spec"
     VERINFO=${VERSION}' (git commit '${GITCOMMIT}')'
+    mkdir -p $RPMROOT/SOURCES/
     tar --exclude .svn -czvf $RPMROOT/SOURCES/$RPMNAME-${VERSION}.tar.gz $RPMNAME
     rm -f $RPMROOT/SRPMS/$RPMNAME-$VER*rpm $RPMROOT/RPMS/noarch/$RPMNAME-$VERSION*rpm
     echo "Building $RPMROOT/RPMS/noarch/$RPMNAME-$VERSION*.noarch.rpm $EMBEDTXT..."


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-inventory/issues/154:
```
[root@c910f03c05k21 xCAT-Incubator]# rm -rf /root/rpmbuild/SOURCES/
[root@c910f03c05k21 xCAT-Incubator]# bash -x ./makepythonrpm xcat-inventory
+ '[' -z xcat-inventory ']'
++ git describe --long --tags
++ cut -d- -f 1
++ tail -c +2
+ VERSION=0.1.5
++ git describe --long --tags
++ cut -d- -f 2
+ NUMCOMMITS=39
+ '[' 39 '!=' 0.1.5 ']'
+ VERSION=0.1.5
+ echo 0.1.5
++ uname
+ OSNAME=Linux
++ git rev-parse HEAD
+ GITCOMMIT=17933160163c1983f222d877d955d721087c5ea3
+ RPMROOT=/root/rpmbuild
+ rpmbuild --version
+ '[' 0 -gt 0 ']'
+ '[' xcat-inventory = xcat-inventory ']'
+ makepythoncli xcat-inventory
+ RPMNAME=xcat-inventory
+ SPEC_FILE=xcat-inventory.spec
+ VERINFO='0.1.5 (git commit 17933160163c1983f222d877d955d721087c5ea3)'
+ mkdir -p /root/rpmbuild/SOURCES/
+ tar --exclude .svn -czvf /root/rpmbuild/SOURCES/xcat-inventory-0.1.5.tar.gz xcat-inventory
xcat-inventory/
xcat-inventory/cli/
xcat-inventory/cli/xcat-inventory
xcat-inventory/debian/
xcat-inventory/debian/control
xcat-inventory/debian/dirs
xcat-inventory/debian/install
xcat-inventory/debian/changelog
xcat-inventory/debian/compat
xcat-inventory/debian/copyright
xcat-inventory/debian/docs
xcat-inventory/debian/source/
xcat-inventory/debian/source/format
xcat-inventory/debian/postinst
xcat-inventory/debian/rules
xcat-inventory/tests/
xcat-inventory/tests/shell_test.py
xcat-inventory/xcclient/
xcat-inventory/xcclient/inventory/
xcat-inventory/xcclient/inventory/__init__.py
xcat-inventory/xcclient/inventory/globalvars.py
xcat-inventory/xcclient/inventory/inventorydiff.py
xcat-inventory/xcclient/inventory/structurediff.py
xcat-inventory/xcclient/inventory/dbobject.py
xcat-inventory/xcclient/inventory/manager.py
xcat-inventory/xcclient/inventory/xcatobj.py
xcat-inventory/xcclient/inventory/schema/
xcat-inventory/xcclient/inventory/schema/1.0/
xcat-inventory/xcclient/inventory/schema/1.0/credential.yaml
xcat-inventory/xcclient/inventory/schema/1.0/network.yaml
xcat-inventory/xcclient/inventory/schema/1.0/node.yaml
xcat-inventory/xcclient/inventory/schema/1.0/osimage.yaml
xcat-inventory/xcclient/inventory/schema/1.0/passwd.yaml
xcat-inventory/xcclient/inventory/schema/1.0/policy.yaml
xcat-inventory/xcclient/inventory/schema/1.0/route.yaml
xcat-inventory/xcclient/inventory/schema/1.0/site.yaml
xcat-inventory/xcclient/inventory/schema/1.0/zone.yaml
xcat-inventory/xcclient/inventory/schema/0.1/
xcat-inventory/xcclient/inventory/schema/0.1/credential.yaml
xcat-inventory/xcclient/inventory/schema/0.1/network.yaml
xcat-inventory/xcclient/inventory/schema/0.1/node.yaml
xcat-inventory/xcclient/inventory/schema/0.1/osimage.yaml
xcat-inventory/xcclient/inventory/schema/0.1/passwd.yaml
xcat-inventory/xcclient/inventory/schema/0.1/policy.yaml
xcat-inventory/xcclient/inventory/schema/0.1/route.yaml
xcat-inventory/xcclient/inventory/schema/0.1/site.yaml
xcat-inventory/xcclient/inventory/schema/0.1/zone.yaml
xcat-inventory/xcclient/inventory/schema/0.2/
xcat-inventory/xcclient/inventory/schema/0.2/credential.yaml
xcat-inventory/xcclient/inventory/schema/0.2/network.yaml
xcat-inventory/xcclient/inventory/schema/0.2/osimage.yaml
xcat-inventory/xcclient/inventory/schema/0.2/passwd.yaml
xcat-inventory/xcclient/inventory/schema/0.2/policy.yaml
xcat-inventory/xcclient/inventory/schema/0.2/route.yaml
xcat-inventory/xcclient/inventory/schema/0.2/site.yaml
xcat-inventory/xcclient/inventory/schema/0.2/zone.yaml
xcat-inventory/xcclient/inventory/schema/0.2/node.yaml
xcat-inventory/xcclient/inventory/schema/2.0/
xcat-inventory/xcclient/inventory/schema/2.0/credential.yaml
xcat-inventory/xcclient/inventory/schema/2.0/network.yaml
xcat-inventory/xcclient/inventory/schema/2.0/networkconn.yaml
xcat-inventory/xcclient/inventory/schema/2.0/node.yaml
xcat-inventory/xcclient/inventory/schema/2.0/osimage.yaml
xcat-inventory/xcclient/inventory/schema/2.0/passwd.yaml
xcat-inventory/xcclient/inventory/schema/2.0/policy.yaml
xcat-inventory/xcclient/inventory/schema/2.0/prodkey.yaml
xcat-inventory/xcclient/inventory/schema/2.0/route.yaml
xcat-inventory/xcclient/inventory/schema/2.0/site.yaml
xcat-inventory/xcclient/inventory/schema/2.0/zone.yaml
xcat-inventory/xcclient/inventory/vutil.py
xcat-inventory/xcclient/inventory/exceptions.py
xcat-inventory/xcclient/inventory/shell.py
xcat-inventory/xcclient/inventory/dbfactory.py
xcat-inventory/xcclient/inventory/dbsession.py
xcat-inventory/xcclient/inventory/utils.py
xcat-inventory/xcclient/__init__.py
xcat-inventory/xcclient/shell.py
xcat-inventory/deps/
xcat-inventory/deps/python-PyMySQL-0.7.6-6.2.noarch.rpm
xcat-inventory/templates/
xcat-inventory/templates/flat_cluster_template.yaml
xcat-inventory/templates/flat_kvm_cluster_template.yaml
xcat-inventory/.gitignore
xcat-inventory/requirements.txt
xcat-inventory/setup.py
xcat-inventory/xcat-inventory.spec
+ rm -f /root/rpmbuild/SRPMS/xcat-inventory-0.1.5-c38.src.rpm /root/rpmbuild/RPMS/noarch/xcat-inventory-0.1.5-c38.noarch.rpm
+ echo 'Building /root/rpmbuild/RPMS/noarch/xcat-inventory-0.1.5*.noarch.rpm ...'
Building /root/rpmbuild/RPMS/noarch/xcat-inventory-0.1.5*.noarch.rpm ...
+ rpmbuild -v -v -v -ta /root/rpmbuild/SOURCES/xcat-inventory-0.1.5.tar.gz --define 'version 0.1.5' --define 'release c39' --define 'gitcommit 17933160163c1983f222d877d955d721087c5ea3'
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.4GtZfI
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd /root/rpmbuild/BUILD
+ rm -rf xcat-inventory
+ /usr/bin/gzip -dc /root/rpmbuild/SOURCES/xcat-inventory-0.1.5.tar.gz
+ /usr/bin/tar -xf -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd xcat-inventory
+ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ exit 0
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.fgxFQM
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd xcat-inventory
+ VERINFO='0.1.5 (git commit 17933160163c1983f222d877d955d721087c5ea3)'
+ sed -i 's/#VERSION_SUBSTITUTE#/0.1.5 (git commit 17933160163c1983f222d877d955d721087c5ea3)/g' /root/rpmbuild/BUILD/xcat-inventory/xcclient/inventory/shell.py
+ exit 0
Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.uqlYrR
+ umask 022
+ cd /root/rpmbuild/BUILD
+ '[' /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le '!=' / ']'
+ rm -rf /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le
++ dirname /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le
+ mkdir -p /root/rpmbuild/BUILDROOT
+ mkdir /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le
+ cd xcat-inventory
+ rm -rf /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le
+ install -d /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le//opt/xcat/bin
+ install -d /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le//opt/xcat/lib/python/xcclient
+ install -d /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le//opt/xcat/lib/python/xcclient/inventory
+ install -d /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le//opt/xcat/lib/python/xcclient/inventory/schema
+ install -d /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le//opt/xcat/share/xcat/inventory_templates
+ install -m755 cli/xcat-inventory /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le//opt/xcat/bin
+ install -m644 xcclient/__init__.py xcclient/shell.py /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le//opt/xcat/lib/python/xcclient
+ install -m644 xcclient/inventory/__init__.py xcclient/inventory/dbfactory.py xcclient/inventory/dbobject.py xcclient/inventory/dbsession.py xcclient/inventory/exceptions.py xcclient/inventory/globalvars.py xcclient/inventory/inventorydiff.py xcclient/inventory/manager.py xcclient/inventory/shell.py xcclient/inventory/structurediff.py xcclient/inventory/utils.py xcclient/inventory/vutil.py xcclient/inventory/xcatobj.py /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le//opt/xcat/lib/python/xcclient/inventory
+ cp -a xcclient/inventory/schema/0.1 xcclient/inventory/schema/0.2 xcclient/inventory/schema/1.0 xcclient/inventory/schema/2.0 /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le//opt/xcat/lib/python/xcclient/inventory/schema
+ cp -a templates/flat_cluster_template.yaml templates/flat_kvm_cluster_template.yaml /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le//opt/xcat/share/xcat/inventory_templates
+ /usr/lib/rpm/find-debuginfo.sh --strict-build-id -m --run-dwz --dwz-low-mem-die-limit 10000000 --dwz-max-die-limit 50000000 /root/rpmbuild/BUILD/xcat-inventory
/usr/lib/rpm/sepdebugcrcfix: Updated 0 CRC32s, 0 CRC32s did match.
+ /usr/lib/rpm/check-buildroot
+ /usr/lib/rpm/redhat/brp-compress
+ /usr/lib/rpm/redhat/brp-strip-static-archive /usr/bin/strip
+ /usr/lib/rpm/brp-python-bytecompile /usr/bin/python 1
+ /usr/lib/rpm/redhat/brp-python-hardlink
+ /usr/lib/rpm/redhat/brp-java-repack-jars
Processing files: xcat-inventory-0.1.5-c39.noarch
Provides: xcat-inventory = 1:0.1.5-c39
Requires(interp): /bin/sh /bin/sh
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PartialHardlinkSets) <= 4.0.4-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires(post): /bin/sh
Requires(preun): /bin/sh
Requires: /usr/bin/env
Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le
Wrote: /root/rpmbuild/SRPMS/xcat-inventory-0.1.5-c39.src.rpm
Wrote: /root/rpmbuild/RPMS/noarch/xcat-inventory-0.1.5-c39.noarch.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.T6MAM6
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd xcat-inventory
+ rm -rf /root/rpmbuild/BUILDROOT/xcat-inventory-0.1.5-c39.ppc64le
+ exit 0
+ '[' 0 -eq 0 ']'
+ ls /root/rpmbuild/RPMS/noarch/xcat-inventory-0.1.5-c39.noarch.rpm
/root/rpmbuild/RPMS/noarch/xcat-inventory-0.1.5-c39.noarch.rpm
+ exit 0
```
