### PR TITLE
fix issue "[FVT]:xcat-inventory import could not find the correct files/dir #153"

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -619,7 +619,10 @@ def importobjdir(location,dryrun=None,version=None,update=True,dbsession=None,en
                 if dryrun:
                     print("copying file: %s ----> %s. Dryrun mode, do nothing..."%(srcfile,myfile),file=sys.stdout)
                 else:
-                    shutil.copyfile(srcfile,myfile)
+                    try:
+                        shutil.copyfile(srcfile,myfile)
+                    except Exception,e:
+                        raise InvalidFileException("Error encountered while copying \"%s\" to \"%s\":\n%s"%(srcfile,myfile,str(e)))
         else:
             print("Warning: the file \""+srcfile+"\" of "+objtype+" \""+objname+"\" does not exist!",file=sys.stderr)
     print("The object "+objname+" has been imported",file=sys.stdout)

--- a/xcat-inventory/xcclient/inventory/vutil.py
+++ b/xcat-inventory/xcclient/inventory/vutil.py
@@ -96,6 +96,11 @@ def getfileanddeplist(infilelist):
         return 
 
     filedict={}
+
+    #in case the input is some ancient inventory format, such as a list of files delimited with COMMA(,) 
+    if type(infilelist) is not list:
+        infilelist=infilelist.split(',')    
+
     for filename in infilelist:
         getincfiledict(filename,filedict)
     return filedict.keys()


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-inventory/issues/153:
* support the old inventory format with ',' delimited string of list
* capture error during file copying
UT:
```
[root@c910f03c01p13 test_myimage]# xcat-inventory import -d /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/cluster_invdir/osimage/test_myimage
loading inventory date in "/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/cluster_invdir/osimage/test_myimage/definition.json"
start to import "osimage" type objects
 preprocessing "osimage" type objects
 writting "osimage" type objects
Inventory import successfully!
Warning: the / already exists, will be overwritten
Error encountered while copying "/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/cluster_invdir/osimage/test_myimage/" to "/":
[Errno 21] Is a directory: '/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/cluster_invdir/osimage/test_myimage/'

[root@c910f03c01p13 test_myimage]# xcat-inventory import -d /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/cluster_invdir/osimage/test_myimage
loading inventory date in "/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/cluster_invdir/osimage/test_myimage/definition.json"
start to import "osimage" type objects
 preprocessing "osimage" type objects
 writting "osimage" type objects
Inventory import successfully!
Warning: the file "/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/cluster_invdir/osimage/test_myimage/tmp/aa" of osimage "test_myimage" does not exist!
Warning: the /tmp/test_myimage/exlist already exists, will be overwritten
Warning: the /tmp/test_myimage/synclists already exists, will be overwritten
Warning: the /tmp/test_myimage/postinstall already exists, will be overwritten
Warning: the /tmp/test_myimage/otherpkglist already exists, will be overwritten
Warning: the /tmp/test_myimage/partitionfile already exists, will be overwritten
The object test_myimage has been imported
[root@c910f03c01p13 test_myimage]#

```
