### PR TITLE
do not write nodelist table for non-node object importing

### DIFF
--- a/xcat-inventory/xcclient/inventory/schema/0.2/node.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/0.2/node.yaml
@@ -14,7 +14,7 @@
       grouptype: "${{objtype=V{obj_type} :  T{nodegroup.grouptype} if objtype == 'group' else None}}"
       members: "${{objtype=V{obj_type} : T{nodegroup.members} if objtype == 'group' else None}}"
       filter: "${{ objtype=V{obj_type} : T{nodegroup.wherevals} if objtype == 'group' else None}}"
-      description: "T{nodelist.comments}"
+      description: "${{ objtype=V{obj_type}: T{nodelist.comments} if objtype=='node' else T{nodegroup.comments} if objtype=='group' else None}}"
     device_type: 
     - "${{ switchname=T{switches.switch}, pduname=T{pdu.node}, objname=V{obj_name}, rackname=T{rack.rackname},hcpname=T{ppchcp.hcp}: 'switch' if switchname == objname else 'pdu' if pduname == objname else 'rack' if rackname == objname else 'hmc' if hcpname == objname else 'server' }}"
     - "W:T{switches.switch}=${{devtype=V{device_type},value=V{obj_name}: value if devtype == 'switch' else None}}"
@@ -80,7 +80,7 @@
         remoteprotocol: 
         - "T{switches.protocol}"
         - "C:${{protocol=V{security_info.remotecontrol.remoteprotocol}: True if str(protocol) in ('','ssh','telnet') else False}}"
-      zonename: "T{nodelist.zonename}"
+      zonename: "${{ objtype=V{obj_type} : T{nodelist.zonename} if objtype == 'node' else None }}"
       product: "T{prodkey.product}"
       productkey: "T{prodkey.key}"
     network_info:
@@ -201,7 +201,7 @@
       nfsserver: "T{noderes.nfsserver}"
       monserver: "T{noderes.monserver}"
       nameservers: "T{noderes.nameservers}"
-      nodelistprimarysn: "T{nodelist.primarysn}"
+      nodelistprimarysn: "${{ objtype=V{obj_type} : T{nodelist.primarysn} if objtype == 'node' else None }}"
       enablesyslog: "T{noderes.syslog}"
       setupnameserver: 
       - "${{role=V{role}: T{servicenode.nameserver} if role == 'service' else None}}"
@@ -257,7 +257,7 @@
       mpaurlpath: "T{mpa.urlpath}"
       nodehmcmdmapping: "T{nodehm.cmdmapping}"
       nodehmgetmac: "T{nodehm.getmac}"
-      nodelisthidden: "T{nodelist.hidden}"
+      nodelisthidden: "${{ objtype=V{obj_type} : T{nodelist.hidden} if objtype == 'node' else None }}"
       noderesnfsdir: "T{noderes.nfsdir}"
       noderesnimserver: "T{noderes.nimserver}"
       noderesprimarynic: "T{noderes.primarynic}"

--- a/xcat-inventory/xcclient/inventory/schema/2.0/node.yaml
+++ b/xcat-inventory/xcclient/inventory/schema/2.0/node.yaml
@@ -14,7 +14,7 @@
       grouptype: "${{objtype=V{obj_type} :  T{nodegroup.grouptype} if objtype == 'group' else None}}"
       members: "${{objtype=V{obj_type} : T{nodegroup.members} if objtype == 'group' else None}}"
       filter: "${{ objtype=V{obj_type} : T{nodegroup.wherevals} if objtype == 'group' else None}}"
-      description: "T{nodelist.comments}"
+      description: "${{ objtype=V{obj_type}: T{nodelist.comments} if objtype=='node' else T{nodegroup.comments} if objtype=='group' else None}}"
     device_type: 
     - "${{ switchname=T{switches.switch}, pduname=T{pdu.node}, objname=V{obj_name}, rackname=T{rack.rackname},hcpname=T{ppchcp.hcp}: 'switch' if switchname == objname else 'pdu' if pduname == objname else 'rack' if rackname == objname else 'hmc' if hcpname == objname else 'server' }}"
     - "W:T{switches.switch}=${{devtype=V{device_type},value=V{obj_name}: value if devtype == 'switch' else None}}"
@@ -80,7 +80,9 @@
         remoteprotocol: 
         - "T{switches.protocol}"
         - "C:${{protocol=V{security_info.remotecontrol.remoteprotocol}: True if str(protocol) in ('','ssh','telnet') else False}}"
-      zonename: "T{nodelist.zonename}"
+      zonename: 
+      - "${{ objtype=V{obj_type} : T{nodelist.zonename} if objtype == 'node' else None }}"
+      - "C:${{ value=V{security_info.zonename}, objtype=V{obj_type} : False if value and objtype != 'node' else True  }}"
       productkey: "REF{prodkey}" 
     network_info:
       linkports: "${{devtype=V{device_type}: T{switches.linkports} if devtype == 'switch' else None}}"
@@ -200,7 +202,9 @@
       nfsserver: "T{noderes.nfsserver}"
       monserver: "T{noderes.monserver}"
       nameservers: "T{noderes.nameservers}"
-      nodelistprimarysn: "T{nodelist.primarysn}"
+      nodelistprimarysn: 
+      - "${{ objtype=V{obj_type} : T{nodelist.primarysn} if objtype == 'node' else None }}"
+      - "C:${{ value=V{role_info.nodelistprimarysn}, objtype=V{obj_type} : False if value and objtype != 'node' else True  }}"
       enablesyslog: "T{noderes.syslog}"
       setupnameserver: 
       - "${{role=V{role}: T{servicenode.nameserver} if role == 'service' else None}}"
@@ -256,7 +260,9 @@
       mpaurlpath: "T{mpa.urlpath}"
       nodehmcmdmapping: "T{nodehm.cmdmapping}"
       nodehmgetmac: "T{nodehm.getmac}"
-      nodelisthidden: "T{nodelist.hidden}"
+      nodelisthidden: 
+      - "${{ objtype=V{obj_type} : T{nodelist.hidden} if objtype == 'node' else None }}" 
+      - "C:${{ value=V{deprecated.nodelisthidden}, objtype=V{obj_type} : False if value and objtype != 'node' else True  }}"
       noderesnfsdir: "T{noderes.nfsdir}"
       noderesnimserver: "T{noderes.nimserver}"
       noderesprimarynic: "T{noderes.primarynic}"


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-inventory/issues/159:

* the columns in `nodelist` table is only valid for node objects
* add the validation criteria
* refine the written of `comments` attribute to node or node group table according to obj_type


UT:
```
[root@c910f03c01p13 2.0]# cat /tmp/bogusnode |grep hidden
      nodelisthidden: abc
[root@c910f03c01p13 2.0]# xcat-inventory import -t node -o bogusnode -f /tmp/bogusnode
loading inventory date in "/tmp/bogusnode"
start to import "node" type objects
 preprocessing "node" type objects
Error: failed to validate attribute [deprecated.nodelisthidden] of object "bogusnode", criteria: " value='abc', objtype='group' : False if value and objtype != 'node' else True  "
[root@c910f03c01p13 2.0]#
```