### PR TITLE
refine the output for Request externals change when importing osimage with xcat-inventory #146

### DIFF
--- a/xcat-inventory/xcclient/inventory/dbfactory.py
+++ b/xcat-inventory/xcclient/inventory/dbfactory.py
@@ -161,7 +161,8 @@ class matrixdbfactory():
         if tabdict is None:
             return None
         for key in tabdict.keys():
-            utils.verbose("  writting object: "+str(key),file=sys.stdout)
+            #utils.verbose("  writting object: "+str(key),file=sys.stdout)
+            print("  importing object: %s"%(str(key)),file=sys.stdout)
             #clear any existing table entries before adding new entries
             df=dbfactory(self._dbsession) 
             df.cleartab(tabdict[key].keys(),[key])

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -261,7 +261,7 @@ class InventoryFactory(object):
         if partialobjdict:
             for subtype in partialobjdict.keys():
                 subhdl = InventoryFactory.createHandler(subtype,self.dbsession,self.schemaversion)
-                subdict=subhdl.importObjs(None,partialobjdict[subtype],update=True,envar=envar)
+                subdict=subhdl.importObjs(None,partialobjdict[subtype],update,envar=envar)
 
         return objfiles
 


### PR DESCRIPTION
fix issue https://github.com/xcat2/xcat-inventory/issues/146:

```
[root@c910f03c05k21 python]# xcat-inventory import  -f /tmp/osimage
loading inventory date in "/tmp/osimage"
start to import "osimage" type objects
 preprocessing "osimage" type objects
 writting "osimage" type objects
  importing object: lsf
  importing object: xcat.redhat.full.netboot
  importing object: compute
  importing object: service
  importing object: bigdata
  importing object: inf
  importing object: gateway
  importing object: time
  importing object: login
  importing object: bigdata_aa_muzyncj_definitions
Inventory import successfully!
``` 