### PR TITLE
support --env-file option to import env variables

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -669,9 +669,9 @@ def importobj(srcfile,srcdir,objtype,objnames=None,dryrun=None,version=None,upda
             try:
                 f = open(env_file)
                 vardict.update( yaml.load(f) )
+                f.close()
             except Exception,e:
-                raise InvalidFileException("Error: Failed to load yaml file '%s', please check ..." % env_file)
-            f.close()
+                raise InvalidFileException("Error: Failed to load variable file '%s', please check ..." % env_file)
 
      if envs:
         for env in envs:

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -487,13 +487,8 @@ def importfromfile(objtypelist, objlist, location,dryrun=None,version=None,updat
     jinjatmpl=jinjaenv.get_template(filename)
     jinjast = jinjaenv.parse(jinjasrc)
     jinjavarlist=meta.find_undeclared_variables(jinjast)
-    vardict={}
+    vardict=envs
       
-    if envs:
-        for env in envs:
-            key, value = env.split('=')
-            vardict[key] = value
-
     # the value '{{OBJNAME}}' indicates that a variable substitute should be taken during import
     if 'OBJNAME' in list(jinjavarlist):
         vardict['OBJNAME']='{{OBJNAME}}'
@@ -655,7 +650,7 @@ def importfromdir(location,objtype='osimage',objnamelist=None,dryrun=None,versio
         dbsession.close()
 
      
-def importobj(srcfile,srcdir,objtype,objnames=None,dryrun=None,version=None,update=True,envs=None):
+def importobj(srcfile,srcdir,objtype,objnames=None,dryrun=None,version=None,update=True,envs=None,env_files=None):
      objtypelist=[]
      importallobjtypes=0
      if objtype:
@@ -666,6 +661,24 @@ def importobj(srcfile,srcdir,objtype,objnames=None,dryrun=None,version=None,upda
      objnamelist=[]
      if objnames:
          objnamelist=[n.strip() for n in objnames.split(',')]
+
+     vardict = {}
+
+     if env_files:
+        for env_file in env_files:
+            try:
+                f = open(env_file)
+                vardict.update( yaml.load(f) )
+            except Exception,e:
+                raise InvalidFileException("Error: Failed to load yaml file '%s', please check ..." % env_file)
+            f.close()
+
+     if envs:
+        for env in envs:
+            key, value = env.split('=')
+            vardict[key] = value 
+
+     envs = vardict
 
      if srcfile and os.path.isfile(srcfile):
          importfromfile(objtypelist, objnamelist,srcfile,dryrun,version,update,envs=envs)

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -41,10 +41,11 @@ class InventoryShell(shell.ClusterShell):
     @shell.arg('--dry', dest='dryrun', action="store_true", default=False, help='Dry run mode, nothing will be commited to xcat database')
     @shell.arg('-c','--clean', dest='update', action="store_false", default=True, help='clean mode. IF specified, all objects other than the ones to import will be removed')
     @shell.arg('-e','--env', dest='env', metavar='<env_var>', action='append', help='the values of variables in object definitions(only available for osimage object), syntax: "<variable name>=<variable value>" , this option can be used multiple times to specify multiple variables')
+    @shell.arg('--env-file', dest='env_file', metavar='<env_file>', action='append', help='the yaml file for variables in object definitions(only available for osimage object), this option can be used multiple times to specify multiple files. If the variable is defined by "-e" option at the same time, will set by "-e" option')
     def do_import(self, args):
         """Import inventory file to xcat database"""
         mgr.validate_args(args, 'import')
-        mgr.importobj(args.path,args.directory,args.type,args.name,dryrun=args.dryrun,version=args.version,update=args.update,envs=args.env)
+        mgr.importobj(args.path,args.directory,args.type,args.name,dryrun=args.dryrun,version=args.version,update=args.update,envs=args.env, env_files=args.env_file)
 
     @shell.arg('-t','--type', metavar='<type>', help='comma "," delimited types of objects to export, valid values: '+','.join(mgr.InventoryFactory.getvalidobjtypes())+'. '+'If not specified, all objects in xcat databse will be exported')
     @shell.arg('-x', '--exclude', dest='exclude', default='', help='types to be excluded when exporting all, delimited with Comma(,).')

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -41,7 +41,7 @@ class InventoryShell(shell.ClusterShell):
     @shell.arg('--dry', dest='dryrun', action="store_true", default=False, help='Dry run mode, nothing will be commited to xcat database')
     @shell.arg('-c','--clean', dest='update', action="store_false", default=True, help='clean mode. IF specified, all objects other than the ones to import will be removed')
     @shell.arg('-e','--env', dest='env', metavar='<env_var>', action='append', help='the values of variables in object definitions(only available for osimage object), syntax: "<variable name>=<variable value>" , this option can be used multiple times to specify multiple variables')
-    @shell.arg('--env-file', dest='env_file', metavar='<env_file>', action='append', help='the yaml file for variables in object definitions(only available for osimage object), this option can be used multiple times to specify multiple files. If the variable is defined by "-e" option at the same time, will set by "-e" option')
+    @shell.arg('--env-file', dest='env_file', metavar='<env_file>', action='append', help='the variable file to set values for variables in inventory file during import. When specified multiple times, the variables in the variable file will overwrite any existing variable. When used with -e option together, the variable value specified with -e will take precedence.')
     def do_import(self, args):
         """Import inventory file to xcat database"""
         mgr.validate_args(args, 'import')


### PR DESCRIPTION
#149 

UT:
```
# xcat-inventory import -h
usage: xcat-inventory import [-t <type>] [-o <name>] [-f <path>]
                             [-d <directory>] [-s <version>] [--dry] [-c]
                             [-e <env_var>] [--env-file <env_file>]

Import inventory file to xcat database

Arguments:
  -t <type>, --type <type>
                        comma "," delimited types of the objects to import,
                        valid values: node,credential,passwd,prodkey,site,netw
                        orkconn,network,zone,route,osimage,policy. If not
                        specified, all objects in the inventory file will be
                        imported
  -o <name>, --objects <name>
                        names of the objects to import, delimited with
                        Comma(,). If not specified, all objects of the
                        specified type in the inventory file will be imported
  -f <path>, --path <path>
                        path of the inventory file to import
  -d <directory>, --dir <directory>
                        path of the inventory directory
  -s <version>, --schema-version <version>
                        schema version of the inventory file. Valid schema
                        versions: latest,1.0. If not specified, the "latest"
                        schema version will be used
  --dry                 Dry run mode, nothing will be commited to xcat
                        database
  -c, --clean           clean mode. IF specified, all objects other than the
                        ones to import will be removed
  -e <env_var>, --env <env_var>
                        the values of variables in object definitions(only
                        available for osimage object), syntax: "<variable
                        name>=<variable value>" , this option can be used
                        multiple times to specify multiple variables
  --env-file <env_file>
                        the variable file to set values for variables in
                        inventory file during import. When specified multiple
                        times, the variables in the variable file will
                        overwrite any existing variable. When used with
                        -e option together, the variable value specified
                        with -e will take precedence.
```

```
# cat /tmp/env.yaml
GITREPO: /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo
SWDIR: /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir

# xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json --env-file /tmp/env.yaml
loading inventory date in "/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json"
start to import "osimage" type objects
 preprocessing "osimage" type objects
 writting "osimage" type objects
Inventory import successfully!

#  lsdef -t osimage test.environments.osimage
Object name: test.environments.osimage
    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo,OBJNAME=test.environments.osimage,SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.5-alternate-ppc64le
    osname=Linux
    osvers=rhels7.5-alternate
    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir/otherpkgdir/
    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test1.otherpkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test2.otherpkglist,
    permission=755
    pkgdir=/install/rhels7.5-alternate/ppc64le,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir/pkgdir/
    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test1.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test2.pkglist
    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/postinstall/test1.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/custom/test.environments.osimage
    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/syncfiles/synclist
    usercomment=rhels7.5,test_environment_variables
```

Load yaml file failed:
```
# xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json --env-file /tmp/env
Error: Failed to load yaml file '/tmp/env', please check ...
```

Run with ``-e`` option:
```
# xcat-inventory import -f /opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json --env-file /tmp/env.yaml -e SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir11111
loading inventory date in "/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/test.environments.osimage.update.json"
start to import "osimage" type objects
 preprocessing "osimage" type objects
 writting "osimage" type objects
Inventory import successfully!

#  lsdef -t osimage test.environments.osimage
Object name: test.environments.osimage
    environvar=GITREPO=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo,OBJNAME=test.environments.osimage,SWDIR=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir11111
    imagetype=linux
    osarch=ppc64le
    osdistroname=rhels7.5-alternate-ppc64le
    osname=Linux
    osvers=rhels7.5-alternate
    otherpkgdir=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir11111/otherpkgdir/
    otherpkglist=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test1.otherpkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/otherpkglist/test2.otherpkglist,
    permission=755
    pkgdir=/install/rhels7.5-alternate/ppc64le,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/swdir11111/pkgdir/  --------------- set value by -e option
    pkglist=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test1.pkglist,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/pkglist/test2.pkglist
    postinstall=/opt/xcat/share/xcat/netboot/rh/compute.rhels7.ppc64le.postinstall,/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/postinstall/test1.postinstall
    profile=compute
    provmethod=netboot
    rootimgdir=/install/custom/test.environments.osimage
    synclists=/opt/xcat/share/xcat/tools/autotest/testcase/xcat-inventory/templates/environment/gitrepo/syncfiles/synclist
    usercomment=rhels7.5,test_environment_variables
```