### PR TITLE
fix issue `import -c` does not work properly on `network_info.connections` and `security_info.productkey` attributes of node #175

### DIFF
--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -261,7 +261,7 @@ class InventoryFactory(object):
         if partialobjdict:
             for subtype in partialobjdict.keys():
                 subhdl = InventoryFactory.createHandler(subtype,self.dbsession,self.schemaversion)
-                subdict=subhdl.importObjs(None,partialobjdict[subtype],update=True,envar=envar)
+                subdict=subhdl.importObjs(None,partialobjdict[subtype],update,envar=envar)
 
         return objfiles
 


### PR DESCRIPTION
fix issue #175 

UT:
```
[root@c910f03c05k21 inventory]# xcat-inventory export -t node
node:
  node1:
    device_type: server
    network_info:
      connections:
      - interface: eth1
        switch: sw1
        switchport: '1'
        vlan: '1'
      - interface: eth2
        switch: sw1
        switchport: '2'
        vlan: '2'
    obj_info:
      groups: all
    obj_type: node
    role: compute
  node2:
    device_type: server
    network_info:
      connections:
      - interface: eth1
        switch: sw2
        switchport: '1'
        vlan: '1'
      - interface: eth2
        switch: sw2
        switchport: '2'
        vlan: '2'
    obj_info:
      groups: all
    obj_type: node
    role: compute
  xcatdefaults:
    device_type: server
    engines:
      netboot_engine:
        engine_info:
          postbootscripts: otherpkgs
          postscripts: syslog,remoteshell,syncfiles
    obj_type: group
    role: compute
schema_version: '2.0'

#Version 2.14.5 (git commit 5bab3f8bac3374cd9cb2e26b4a71c7cb32bb1126, built Mon Oct 22 06:16:06 EDT 2018)
[root@c910f03c05k21 inventory]#

[root@c910f03c05k21 inventory]# xcat-inventory import -f /tmp/node3 -c
loading inventory date in "/tmp/node3"
start to import "node" type objects
 preprocessing "node" type objects
 writting "node" type objects
start to import "networkconn" type objects
 preprocessing "networkconn" type objects
 writting "networkconn" type objects
Inventory import successfully!
[root@c910f03c05k21 inventory]# xcat-inventory export -t node
node:
  node3:
    device_type: server
    network_info:
      connections:
        interface: eth3
        switch: sw3
        switchport: '3'
        vlan: '3'
    obj_info:
      groups: all
    obj_type: node
    role: compute
  xcatdefaults:
    device_type: server
    engines:
      netboot_engine:
        engine_info:
          postbootscripts: otherpkgs
          postscripts: syslog,remoteshell,syncfiles
    obj_type: group
    role: compute
schema_version: '2.0'

#Version 2.14.5 (git commit 5bab3f8bac3374cd9cb2e26b4a71c7cb32bb1126, built Mon Oct 22 06:16:06 EDT 2018)
[root@c910f03c05k21 inventory]#
```