### PR TITLE
update the README to add XCAT_VERNO and XCAT_SERVER variable for running in container

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,17 @@ Building /root/rpmbuild/RPMS/noarch/xcat-inventory-0.1.4*.noarch.rpm ...
 You can tag and push it to your dock registry (for example, xcatdevops/xcat-apiserver:latest), and then you can run it on an xCAT management node with below:
 
 ```
-docker run -it -v /etc/xcat:/etc/xcat -v `pwd`/xcat-inventory:/xcat-apiserver -p 5000:5000 xcatdevops/xcat-apiserver /bin/bash
+# cd <Git clone directory>
+# docker run -it -v /etc/xcat:/etc/xcat -v `pwd`/xcat-inventory:/xcat-apiserver -p 5000:5000 xcatdevops/xcat-apiserver /bin/bash
 # source /venv/bin/activate
-# FLASK_DEBUG=1 python main.py
-
+# FLASK_DEBUG=1 XCAT_VERNO=2.14.6 XCAT_SERVER=10.3.5.20 python main.py
 ```
+Note:
+
+- To run on ppc64le platform, you need to find the right tag to be use.
+- To run in container, it requires to pass the xcat version and server IP.
+
+
 ## Dependency
 
 Several python packages are required:


### PR DESCRIPTION
Just update the document to add more information about `XCAT_VERNO` and `XCAT_SERVER` when running in container.
