### PR TITLE
Implement Site restful APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Building /root/rpmbuild/RPMS/noarch/xcat-inventory-0.1.4*.noarch.rpm ...
 You can tag and push it to your dock registry (for example, xcatdevops/xcat-apiserver:latest), and then you can run it on an xCAT management node with below:
 
 ```
-docker run -it -v /etc/xcat:/etc/xcat -v `pwd`/xcat-inventory:/xcat-apiserver -p 5000:5000 xcatdevops/xcat-apiserver /bin/bash
+docker run -it -v /etc/xcat:/etc/xcat -v /root/.xcat:/root/.xcat -v `pwd`/xcat-inventory:/xcat-apiserver -p 5000:5000 xcatdevops/xcat-apiserver /bin/bash
 # source /venv/bin/activate
-# FLASK_DEBUG=1 python main.py
+# FLASK_DEBUG=1 XCAT_VERNO=2.14.6 XCAT_SERVER=127.0.0.1 python main.py
 
 ```
 ## Dependency

--- a/xcat-inventory/xcclient/allien/app.py
+++ b/xcat-inventory/xcclient/allien/app.py
@@ -7,7 +7,6 @@
 """The app module, containing the app factory function."""
 
 import os
-from datetime import timedelta
 import logging
 from flask import Flask, Blueprint
 
@@ -15,6 +14,7 @@ from flask_caching import Cache
 # from .extensions import bcrypt, cache, db, migrate, jwt, cors
 
 from xcclient.xcatd.client import xcat_log
+from xcclient.xcatd.client.xcat_exceptions import XCATClientError
 from xcclient.inventory.dbsession import DBsession
 from xcclient.inventory.dbfactory import dbfactory
 from xcclient.inventory.utils import initglobal
@@ -56,7 +56,7 @@ def create_app(config_object=None):
     register_logger(app)
     register_extensions(app)
     register_blueprints(app)
-    #register_errorhandlers(app)
+    register_errorhandlers(app)
     #register_shellcontext(app)
     #register_commands(app)
 
@@ -107,7 +107,7 @@ def register_errorhandlers(app):
         response.status_code = error.status_code
         return response
 
-    app.errorhandler(InvalidUsage)(errorhandler)
+    app.errorhandler(XCATClientError)(errorhandler)
 
 
 def register_shellcontext(app):

--- a/xcat-inventory/xcclient/allien/invmanager.py
+++ b/xcat-inventory/xcclient/allien/invmanager.py
@@ -6,6 +6,8 @@
 
 from flask import g
 
+from xcclient.xcatd import XCATClient, XCATClientParams
+
 from .app import dbi, dbsession, cache
 from .noderange import NodeRange
 from ..inventory.manager import InventoryFactory
@@ -162,10 +164,17 @@ def upd_inventory_by_type(objtype, obj_attr_dict, clean=False):
 
 
 def del_inventory_by_type(objtype, obj_list):
-    hdl = InventoryFactory.createHandler(objtype, dbsession, None)
+    """delete objects from data store"""
+    # hdl = InventoryFactory.createHandler(objtype, dbsession, None)
 
-    return hdl.importObjs(obj_list, {}, update=False, envar={})
+    #return hdl.importObjs(obj_list, {}, update=False, envar={})
 
+    param = XCATClientParams(os.environ.get('XCAT_SERVER'))
+    cl = XCATClient()
+    cl.init(current_app.logger, param)
+
+    result = cl.rmdef(args=['-t', objtype, '-o', ','.join(obj_list)])
+    return result.output_msgs
 
 def transform_from_inv(obj_d):
     """transform the inventory object model(dict for collection) to a list"""

--- a/xcat-inventory/xcclient/allien/invmanager.py
+++ b/xcat-inventory/xcclient/allien/invmanager.py
@@ -160,7 +160,8 @@ def get_inventory_by_type(objtype, ids=None):
 def upd_inventory_by_type(objtype, obj_attr_dict, clean=False):
     hdl = InventoryFactory.createHandler(objtype, dbsession, None)
 
-    return hdl.importObjs(obj_attr_dict.keys(), obj_attr_dict, update=not clean, envar={})
+    hdl.importObjs(obj_attr_dict.keys(), obj_attr_dict, update=not clean, envar={})
+    dbsession.commit()
 
 
 def del_inventory_by_type(objtype, obj_list):

--- a/xcat-inventory/xcclient/allien/invmanager.py
+++ b/xcat-inventory/xcclient/allien/invmanager.py
@@ -4,6 +4,7 @@
 
 # -*- coding: utf-8 -*-
 
+import os
 from flask import g
 
 from xcclient.xcatd import XCATClient, XCATClientParams
@@ -170,7 +171,7 @@ def del_inventory_by_type(objtype, obj_list):
 
     #return hdl.importObjs(obj_list, {}, update=False, envar={})
 
-    param = XCATClientParams(os.environ.get('XCAT_SERVER'))
+    param = XCATClientParams(xcatmaster=os.environ.get('XCAT_SERVER'))
     cl = XCATClient()
     cl.init(current_app.logger, param)
 

--- a/xcat-inventory/xcclient/allien/resources/site.py
+++ b/xcat-inventory/xcclient/allien/resources/site.py
@@ -114,12 +114,12 @@ class SiteAttrResource(Resource):
         if not args.get('value'):
             ns.abort(400, 'Context not found')
 
-        param = XCATClientParams(os.environ.get('XCAT_SERVER'))
+        param = XCATClientParams(xcatmaster=os.environ.get('XCAT_SERVER'))
         cl = XCATClient()
         cl.init(current_app.logger, param)
 
         result = cl.chdef(args=['-t', 'site', '-o', context, "%s=%s" % (attr, args.get('value'))])
-        return result.output_msgs
+        return dict(outputs=result.output_msgs)
 
     @ns.doc('delete_site_attr')
     def delete(self, context, attr):
@@ -128,9 +128,9 @@ class SiteAttrResource(Resource):
         if "clustersite" != context:
             ns.abort(404, 'Context not found')
 
-        param = XCATClientParams(os.environ.get('XCAT_SERVER'))
+        param = XCATClientParams(xcatmaster=os.environ.get('XCAT_SERVER'))
         cl = XCATClient()
         cl.init(current_app.logger, param)
 
         result = cl.chdef(args=['-t', 'site', '-o', context, "%s=" % (attr, )])
-        return result.output_msgs
+        return dict(outputs=result.output_msgs)

--- a/xcat-inventory/xcclient/allien/resources/site.py
+++ b/xcat-inventory/xcclient/allien/resources/site.py
@@ -4,72 +4,131 @@
 
 # -*- coding: utf-8 -*-
 
-from flask_restplus import Namespace, Resource, fields, reqparse
-from xcclient.allien.app import dbi
-from ..invmanager import get_inventory_by_type, upd_inventory_by_type, del_inventory_by_type, transform_from_inv, transform_to_inv
+import os
+from flask import request, current_app
+from flask_restplus import Namespace, Resource, reqparse
+
+from ..invmanager import get_inventory_by_type, upd_inventory_by_type, transform_from_inv, transform_to_inv
+from ..invmanager import InvalidValueException, ParseException
+from .inventory import resource
 
 ns = Namespace('globalconf', description='System Level Settings')
-
-site = ns.model('Site', {
-    'name': fields.String(required=True, description='The attribute name'),
-    'value': fields.String(required=True, description='The attribute value'),
-})
-
-site_list = ns.model('Site', {
-    'name': fields.String(required=True, description='The attribute name'),
-    'value': fields.String(required=True, description='The attribute value'),
-})
-
 
 @ns.route('/sites')
 class SitesResource(Resource):
 
+    @ns.doc('list_sites')
     def get(self):
+        """List all site contexts"""
         return transform_from_inv(get_inventory_by_type('site'))
 
-    @ns.expect(site)
-    def post(self):
-        pass
-
-
-@ns.route('/sites/<name>')
+@ns.route('/sites/<string:context>')
 @ns.response(404, 'Context not found')
 class SiteResource(Resource):
-    @ns.doc('list_site')
-    @ns.param('attr', 'The site attribute name')
+
+    @ns.doc('get_site')
+    @ns.param('attrs', 'Site attribute names')
     def get(self, context):
-        """List all site attributes"""
+        """Get the attributes of specified context ( only 'clustersite' allowed now )"""
+
         parser = reqparse.RequestParser()
         parser.add_argument('attrs', location='args', action='split', help='Queried attributes')
         args = parser.parse_args()
-        # print(args)
-        return dbi.gettab(['site'])
 
-    def put(self):
-        """Modify site with all attributes"""
-        return dbi.gettab(['site'])
+        result = get_inventory_by_type('site', [context])
+        if not result:
+            ns.abort(404)
 
-    def patch(self):
-        """Modify some attributes of site"""
-        return dbi.gettab(['site'])
+        if not args.get('attrs'):
+            return transform_from_inv(result)[-1]
+
+        site_obj = result.get(context)
+        temp_spec = {}
+        for attr in args.get('attrs'):
+           temp_spec[attr] = site_obj.get(attr)
+
+        return {'meta': {'name':context}, 'spec':temp_spec}
+
+    @ns.expect(resource)
+    def put(self, context):
+        """Replace site context with all attributes"""
+
+        data = request.get_json()
+
+        # TODO: better to handle the exceptions
+        try:
+            upd_inventory_by_type('site', transform_to_inv(data), clean=True)
+        except (InvalidValueException, ParseException) as e:
+            ns.abort(400, e.message)
+
+        return None, 201
+
+    def patch(self, context):
+        """Modify attributes of a site context"""
+
+        data = request.get_json()
+
+        # TODO: better to handle the exceptions
+        try:
+            upd_inventory_by_type('site', transform_to_inv(data))
+        except (InvalidValueException, ParseException) as e:
+            ns.abort(400, e.message)
+
+        return None, 201
 
 
-@ns.route('/sites/<name>/attr/<attr>')
-@ns.param('name', 'The site context name')
+@ns.route('/sites/<context>/<attr>')
+@ns.param('context', 'The site context name')
 @ns.param('attr', 'The site attribute name')
 @ns.response(404, 'Attribute not found')
 class SiteAttrResource(Resource):
+
     @ns.doc('get_site_attr')
-    # @ns.marshal_with(site)
-    def get(self, attr):
-        """Fetch a site attribute given its name"""
-        for nv in SITES:
-            if attr['name'] == nv:
-                return attr['value']
-        ns.abort(404)
+    def get(self, context, attr):
+        """Fetch a site attribute by the given name"""
 
+        result = get_inventory_by_type('site', [context])
+        if not result:
+            ns.abort(404, 'Context not found')
 
+        site_obj = result.get(context)
+        if attr not in site_obj:
+            ns.abort(404, 'Attribute not found')
 
+        return {attr: site_obj.get(attr)}
 
+    @ns.doc('set_site_attr')
+    @ns.response(400, 'Must specify the value in query parameter.')
+    def post(self, context, attr):
+        """Set a site attribute by the given name"""
 
+        if "clustersite" != context:
+            ns.abort(404, 'Context not found')
 
+        parser = reqparse.RequestParser()
+        parser.add_argument('value', location='args', help='Value to be set on the attribute')
+        args = parser.parse_args()
+
+        if not args.get('value'):
+            ns.abort(400, 'Context not found')
+
+        param = XCATClientParams(os.environ.get('XCAT_SERVER'))
+        cl = XCATClient()
+        cl.init(current_app.logger, param)
+
+        result = cl.chdef(args=['-t', 'site', '-o', context, "%s=%s" % (attr, args.get('value'))])
+        return result.output_msgs
+
+    @ns.doc('delete_site_attr')
+    def delete(self, context, attr):
+        """Delete a site attribute by the given name"""
+
+        if "clustersite" != context:
+            ns.abort(404, 'Context not found')
+
+        param = XCATClientParams(os.environ.get('XCAT_SERVER'))
+        cl = XCATClient()
+        cl.init(current_app.logger, param)
+
+        result = cl.chdef(args=['-t', 'site', '-o', context, "%s=" % (attr, )])
+        return result.output_msgs

--- a/xcat-inventory/xcclient/allien/resources/site.py
+++ b/xcat-inventory/xcclient/allien/resources/site.py
@@ -100,6 +100,7 @@ class SiteAttrResource(Resource):
         return {attr: site_obj.get(attr)}
 
     @ns.doc('set_site_attr')
+    @ns.param('value', 'Value set to the attribute')
     @ns.response(400, 'Must specify the value in query parameter.')
     def post(self, context, attr):
         """Set a site attribute by the given name"""

--- a/xcat-inventory/xcclient/allien/resources/site.py
+++ b/xcat-inventory/xcclient/allien/resources/site.py
@@ -6,7 +6,7 @@
 
 from flask_restplus import Namespace, Resource, fields, reqparse
 from xcclient.allien.app import dbi
-from ..invmanager import get_inventory_by_type
+from ..invmanager import get_inventory_by_type, upd_inventory_by_type, del_inventory_by_type, transform_from_inv, transform_to_inv
 
 ns = Namespace('globalconf', description='System Level Settings')
 
@@ -25,7 +25,7 @@ site_list = ns.model('Site', {
 class SitesResource(Resource):
 
     def get(self):
-        return get_inventory_by_type('site')
+        return transform_from_inv(get_inventory_by_type('site'))
 
     @ns.expect(site)
     def post(self):

--- a/xcat-inventory/xcclient/allien/resources/site.py
+++ b/xcat-inventory/xcclient/allien/resources/site.py
@@ -8,6 +8,8 @@ import os
 from flask import request, current_app
 from flask_restplus import Namespace, Resource, reqparse
 
+from xcclient.xcatd import XCATClient, XCATClientParams
+
 from ..invmanager import get_inventory_by_type, upd_inventory_by_type, transform_from_inv, transform_to_inv
 from ..invmanager import InvalidValueException, ParseException
 from .inventory import resource


### PR DESCRIPTION
Implement the Site restful APIs (https://github.ibm.com/xcat2/task_management/issues/140):
- `/globalconf/sites`  GET (no need for POST as now only one default context)
- `/globalconf/sites/<context>`  GET/PUT/PATCH (For GET, supporting query parameters of attributes)
- `/globalconf/sites/<context>/<attr>` GET/POST/DELETE

Implement a general delete method `del_inventory_by_type` in `invmanager.py`, it will call xcatd client to do a `rmdef` action.

Waiting full UT.