### PR TITLE
python3 supporting

### DIFF
--- a/xcat-inventory/xcclient/inventory/backend.py
+++ b/xcat-inventory/xcclient/inventory/backend.py
@@ -5,17 +5,18 @@ import configparser
 import os
 import shutil
 import re
-import sys
-from exceptions import * 
-import manager 
-import utils
 import pickle
 import hashlib
+
+from .exceptions import *
+from . import manager
+from . import utils
 
 try:
     import sh
 except:
     raise InternalException("cannot find module \"sh\", please install it with \"pip install sh\"")
+
 
 class Invbackend(object):
 

--- a/xcat-inventory/xcclient/inventory/dbfactory.py
+++ b/xcat-inventory/xcclient/inventory/dbfactory.py
@@ -1,12 +1,18 @@
 #!/usr/bin/python
 from __future__ import print_function
-import dbobject
-from dbobject import *
-from dbsession import DBsession
+import sys
+
+try:
+    from . import dbobject
+    from .dbobject import *
+except Exception:
+    print("Failed to connected with database...")
+
+
 from sqlalchemy import or_
 #from xcclient.shell import CommandException
-from exceptions import *
-import utils
+from .exceptions import *
+from . import utils
 
 def create_or_update(session,tabcls,key,newdict,ismatrixtable=True):
     tabkeys=tabcls.primkeys()
@@ -60,14 +66,14 @@ def create_or_update(session,tabcls,key,newdict,ismatrixtable=True):
         for tabkey in tabkeys:
             query=query.filter(getattr(tabcls,tabkey) == newdict[tabkey])
         record=query.all()
-    except Exception, e:
+    except Exception as e:
         raise DBException("Error: query xCAT table "+tabcls.__tablename__+" failed: "+str(e))
     if record:
         if delrow:
             try:
                 for item in record:
                     session.delete(item)
-            except Exception, e:
+            except Exception as e:
                 raise DBException("Error: delete "+key+" is failed: "+str(e))
             #else:
             #    print("delete row in xCAT table "+tabcls.__tablename__+".")
@@ -77,12 +83,12 @@ def create_or_update(session,tabcls,key,newdict,ismatrixtable=True):
                #for tabkey in tabkeys:
                #    query=query.filter(getattr(tabcls,tabkey) == newdict[tabkey])
                query.update(newdict)
-           except Exception, e:
+           except Exception as e:
                raise DBException("Error: import object "+key+" is failed: "+str(e))
     elif delrow == 0:
         try:
             session.execute(tabcls.__table__.insert(), newdict)
-        except Exception, e:
+        except Exception as e:
             raise DBException("Error: import object "+key+" is failed: "+str(e)) 
 
 class matrixdbfactory():
@@ -99,10 +105,11 @@ class matrixdbfactory():
                continue
            tabobjs=[]
            tabkeys=tab.primkeys()
-           if len(keys)==0:
+           if not keys or len(keys)==0:
                tabobjs=dbsession.query(tab).filter(or_(tab.disable == None, tab.disable.notin_(['1','yes']))).all()
            elif len(tabkeys)==1:
-               tabobjs=dbsession.query(tab).filter(getattr(tab,tabkeys[0]).in_(keys),or_(tab.disable == None, tab.disable.notin_(['1','yes']))).all()
+               tabobjs = dbsession.query(tab).filter(getattr(tab, tabkeys[0]).in_(keys),
+                                                     or_(tab.disable == None, tab.disable.notin_(['1', 'yes']))).all()
            elif len(tabkeys)>1:
                for key in keys:
                    if type(key)!=tuple:
@@ -149,8 +156,8 @@ class matrixdbfactory():
                    ret[mykey].update(dictoftab[mykey])
 
         for mykey in ret.keys():
-            if len(ret[mykey].keys())==1 and ret[mykey].keys()[0] in tabs :
-                ret[mykey]=ret[mykey][ret[mykey].keys()[0]]          
+            if len(ret[mykey].keys())==1 and list(ret[mykey].keys())[0] in tabs :
+                ret[mykey]=ret[mykey][list(ret[mykey].keys())[0]]
 
         return ret 
 
@@ -333,7 +340,7 @@ class dbfactory():
                 if objkey:
                     query=query.filter(getattr(tabcls,tabkey).in_(objkey)) 
                 query.delete(synchronize_session='fetch')
-            except Exception, e:
+            except Exception as e:
                 raise DBException("Error: failed to clear table "+str(tab)+": "+str(e))
         #else:
         #    print("table "+tab+ "cleared!")

--- a/xcat-inventory/xcclient/inventory/dbobject.py
+++ b/xcat-inventory/xcclient/inventory/dbobject.py
@@ -1,8 +1,11 @@
 #!/usr/bin/python
-from dbsession import *
+
 from copy import *
 from sqlalchemy import inspect
-import pdb
+# import pdb
+
+from .dbsession import *
+
 
 class mixin(object):
     def getdict(self):

--- a/xcat-inventory/xcclient/inventory/dbobject.py
+++ b/xcat-inventory/xcclient/inventory/dbobject.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import sys
 from copy import *
 from sqlalchemy import inspect
 # import pdb
@@ -11,8 +12,15 @@ class mixin(object):
     def getdict(self):
         mydict={}
         for mykey in self.__dict__.keys():
-           if mykey in self.__table__.columns:
-              mydict[self.__tablename__+'.'+mykey.encode()]= self.__dict__[mykey] if self.__dict__[mykey] is None else self.__dict__[mykey].encode()
+            if mykey in self.__table__.columns:
+                myvalue = self.__dict__[mykey]
+                if sys.version_info < (3,0):
+                    if type(mykey) is unicode:
+                        mykey = mykey.encode()
+
+                    if type(myvalue) is unicode:
+                        myvalue = myvalue.encode()
+                mydict["%s.%s" % (self.__tablename__, mykey)]= myvalue
         try:
             self.__class__.outprocess(mydict)
         except:
@@ -24,7 +32,7 @@ class mixin(object):
     def primkeys(cls):
         ins = inspect(cls)
         prikeys=[ item.key for item in ins.primary_key ]
-        prikeys.sort(None,None,reverse=False)
+        prikeys.sort(reverse=False)
         return tuple(prikeys)
 
     #return the key of object in table row

--- a/xcat-inventory/xcclient/inventory/dbsession.py
+++ b/xcat-inventory/xcclient/inventory/dbsession.py
@@ -117,7 +117,8 @@ class DBsession(Singleton):
             self._sessions[session].commit()
     #close all sessions
     def close(self):
-        for session in self._sessions.keys():
+        se_list = list(self._sessions.keys())
+        for session in se_list:
             self._sessions[session].close()
             del self._sessions[session]
         

--- a/xcat-inventory/xcclient/inventory/dbsession.py
+++ b/xcat-inventory/xcclient/inventory/dbsession.py
@@ -10,9 +10,10 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 import re
 import os
-import sqlalchemy.exc
-from exceptions import *
+#import sqlalchemy.exc
 import codecs
+
+from .exceptions import *
 
 codecs.register(lambda name: codecs.lookup('utf8') if name == 'utf8mb4' else None)
 
@@ -103,7 +104,7 @@ class DBsession(Singleton):
                 return self._sessions[tablename]
         else:    
             if self._sessions:
-                mykey=self._sessions.keys()[0]
+                mykey=list(self._sessions.keys())[0]
                 return self._sessions[mykey]
             else:
                 session=self.__class__.createSession(tablename)

--- a/xcat-inventory/xcclient/inventory/globalvars.py
+++ b/xcat-inventory/xcclient/inventory/globalvars.py
@@ -1,18 +1,18 @@
 
-#xcat version string
-xcat_version=""
+# xcat version string
+xcat_version = ""
 
-#xcat version number
-xcat_verno=""
+# xcat version number
+xcat_verno = ""
 
-#xcat service running?
-isxcatrunning=0
+# xcat service running?
+isxcatrunning = 0
 
-implicitEnvVars={'OBJNAME':{'description':"the object name to import"},
-                 'GITROOT':{'description':"the root path of the git repo where the inventory file resides in"},
-                 'GITBRANCH':{'description':"the current git branch name of the inventory file to import"},
-                 'GITTAG':{'description':"the current git tag of the inventory file to import"},
-                 'GITCOMMIT':{'description':"the current git commit number of the inventory file to import"}}
+implicitEnvVars = {'OBJNAME':{'description':"the object name to import"},
+                   'GITROOT':{'description':"the root path of the git repo where the inventory file resides in"},
+                   'GITBRANCH':{'description':"the current git branch name of the inventory file to import"},
+                   'GITTAG':{'description':"the current git tag of the inventory file to import"},
+                   'GITCOMMIT':{'description':"the current git commit number of the inventory file to import"}}
 
-#verbose?
-verbose=False
+# verbose or not
+verbose = False

--- a/xcat-inventory/xcclient/inventory/inventorydiff.py
+++ b/xcat-inventory/xcclient/inventory/inventorydiff.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-from structurediff import StructureDiff
-import manager as mgr 
-from exceptions import *
-from utils import *
-import re
+
+from .structurediff import StructureDiff
+from . import manager as mgr
+from .utils import *
+
 
 def line_diff(file1, file2, filename=None):
     (retcode,out,err)=runCommand("diff -u %s %s"%(file1, file2))

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -6,20 +6,22 @@
 #
 
 from __future__ import print_function
-from dbsession import DBsession
-from dbfactory import dbfactory
-from xcatobj import *
-from exceptions import *
-from utils import *
-import globalvars
 import os
 import shutil
-from jinja2 import Template,Environment,meta,FileSystemLoader
+from jinja2 import Environment,meta,FileSystemLoader
+import json
 import yaml
 try:
     from yaml import CLoader as Loader
 except ImportError:
     from yaml import Loader
+
+from .dbsession import DBsession
+from .dbfactory import dbfactory
+from .xcatobj import *
+from .exceptions import *
+from . import utils
+from . import globalvars
 
 """
 Command-line interface to xCAT inventory import/export
@@ -92,7 +94,7 @@ class InventoryFactory(object):
             try:
                 myclass = InventoryFactory.__InventoryClass__[objtype]
                 myclass.validate_schema_version(schemapath)
-            except Exception,e:
+            except Exception:
                 continue
             return ver   
         return None
@@ -135,7 +137,7 @@ class InventoryFactory(object):
                 for attr in attrs:
                     newsubobj=myclass.createfromdb(key, attr)
                     subobjdict=newsubobj.getobjdict()
-                    objdictkey=subobjdict.keys()[0]
+                    objdictkey=list(subobjdict.keys())[0]
                     if objdictkey not in myobjdict.keys():
                         myobjdict[objdictkey]=[]
                     myobjdict[objdictkey].append(subobjdict[objdictkey])
@@ -165,7 +167,7 @@ class InventoryFactory(object):
                         dstfile=mydir+filetobak
                         try:
                             os.makedirs(os.path.dirname(dstfile))
-                        except OSError, e:
+                        except OSError as e:
                             if e.errno != os.errno.EEXIST:
                                 raise
                             pass
@@ -216,15 +218,15 @@ class InventoryFactory(object):
 
         for key, attrs in obj_attr_dict.items():
                  
-            verbose("  converting object \"%s\" to table entries"%(key),file=sys.stdout)
+            utils.verbose("  converting object \"%s\" to table entries"%(key),file=sys.stdout)
             if not objlist or key in objlist:
                 if 'OBJNAME' in envar.keys() and type(attrs)==dict:
                     envar['OBJNAME']=key
-                    Util_subvarsindict(attrs,envar)    
+                    utils.Util_subvarsindict(attrs,envar)
                 else:
                     envar['OBJNAME']=key
                 if self.objtype == 'osimage' and envar is not None:
-                    Util_setdictval(attrs,'environvars',','.join([item+'='+envar[item] for item in envar.keys()]))   
+                    utils.Util_setdictval(attrs,'environvars',','.join([item+'='+envar[item] for item in envar.keys()]))
 
                 objfiles[key]=[]
                 attrlist=[]
@@ -237,11 +239,11 @@ class InventoryFactory(object):
                     for (attrpath,reftype) in outrefs.items():
                         partialobj=utils.Util_getdictval(attr,attrpath)
                         if partialobj:
-                            Util_setdictval(partialobjdict,"%s.%s"%(reftype[0],key),partialobj)
-                            Util_deldictkey(attr,attrpath)
+                            utils.Util_setdictval(partialobjdict,"%s.%s"%(reftype[0],key),partialobj)
+                            utils.Util_deldictkey(attr,attrpath)
                     try:
                         newobj = myclass.createfromfile(key, attr)
-                    except InvalidValueException,e:
+                    except InvalidValueException as e:
                         exptmsglist.append(str(e)) 
                         continue
                     objfiles[key].extend(newobj.getfilestosave(rootdir))
@@ -455,7 +457,7 @@ def getgitinfo(location):
     vardict={}
     oldcwd=os.getcwd()
     os.chdir(os.path.dirname(os.path.realpath(location)))
-    (retcode,out,err)=runCommand("git rev-parse --show-toplevel")
+    (retcode,out,err)=utils.runCommand("git rev-parse --show-toplevel")
     if retcode==0:
         out=out.strip()
         vardict['GITROOT']=out.strip()
@@ -464,7 +466,7 @@ def getgitinfo(location):
         os.chdir(oldcwd)
         return None
 
-    (retcode,out,err)=runCommand("git branch|grep '*'|cut -d' ' -f2-")
+    (retcode,out,err)=utils.runCommand("git branch|grep '*'|cut -d' ' -f2-")
     if retcode==0:
         out=out.strip()
         matched=re.search(r'\(detached from (.*)\)',out)
@@ -472,13 +474,13 @@ def getgitinfo(location):
             out=matched.group(1).strip()
         vardict['GITBRANCH']=out
 
-    (retcode,out,err)=runCommand("git describe  --candidates 0")
+    (retcode,out,err)=utils.runCommand("git describe  --candidates 0")
     if retcode==0:
         out=out.strip()
         matched=re.search(r'\(detached from (.*)',out)
         vardict['GITTAG']=out.strip()
     
-    (retcode,out,err)=runCommand("git rev-parse --short=7 HEAD")
+    (retcode,out,err)=utils.runCommand("git rev-parse --short=7 HEAD")
     if retcode==0:
         out=out.strip()
         vardict['GITCOMMIT']=out.strip()
@@ -525,7 +527,7 @@ def importfromfile(objtypelist,objlist,filepath,dryrun=None,version=None,update=
     except ValueError:
         try: 
             obj_attr_dict = yaml.load(contents,Loader=Loader)
-        except Exception,e:
+        except Exception as e:
             raise InvalidFileException("Error: failed to load file \"%s\", please validate the file with 'yamllint %s'(for yaml format) or 'cat %s|python -mjson.tool'(for json format)!"%(location,location,location))
   
     versinfile=None
@@ -558,7 +560,7 @@ def importfromfile(objtypelist,objlist,filepath,dryrun=None,version=None,update=
                 objfiledict[myobjtype]={}
             try: 
                 objfiledict[myobjtype].update(hdl.importObjs(objlist, obj_attr_dict[myobjtype],update,envar,rootdir))
-            except InvalidValueException,e:
+            except InvalidValueException as e:
                 exptmsglist.append(str(e))
                 continue
     else:
@@ -570,7 +572,7 @@ def importfromfile(objtypelist,objlist,filepath,dryrun=None,version=None,update=
                 objfiledict[objtype]={}
             try: 
                 objfiledict[objtype].update(hdl.importObjs([], obj_attr_dict[objtype],update,envar,rootdir))
-            except InvalidValueException,e:
+            except InvalidValueException as e:
                 exptmsglist.append(str(e))
                 continue
 
@@ -579,7 +581,7 @@ def importfromfile(objtypelist,objlist,filepath,dryrun=None,version=None,update=
     if not dryrun:
         try:
             dbsession.commit()   
-        except Exception, e: 
+        except Exception as e:
             raise DBException("Error on commit DB transactions: "+str(e))
         else:
             print('Inventory import successfully!',file=sys.stdout)
@@ -603,11 +605,11 @@ def importobjdir(location,dryrun=None,version=None,update=True,dbsession=None,en
     if len(objfilesdict.keys()) !=1:
         raise InvalidFileException("Error: invalid definition file: \""+objfile+"\": should contain only 1 object type")  
     else:
-        objtype=objfilesdict.keys()[0]
+        objtype=list(objfilesdict.keys())[0]
     if len(objfilesdict[objtype].keys()) !=1:
         raise InvalidFileException("Error: invalid definition file: \""+objfile+"\": should contain only 1 object")
     else:
-        objname=objfilesdict[objtype].keys()[0]
+        objname=list(objfilesdict[objtype].keys())[0]
     objfiles=objfilesdict[objtype][objname]
     for myfile in objfiles:
         srcfile=location+myfile
@@ -617,7 +619,7 @@ def importobjdir(location,dryrun=None,version=None,update=True,dbsession=None,en
             else:
                 try:
                     os.makedirs(os.path.dirname(myfile))
-                except OSError, e:
+                except OSError as e:
                     if e.errno != os.errno.EEXIST:
                         raise
                     pass
@@ -631,7 +633,7 @@ def importobjdir(location,dryrun=None,version=None,update=True,dbsession=None,en
                 else:
                     try:
                         shutil.copyfile(srcfile,myfile)
-                    except Exception,e:
+                    except Exception as e:
                         raise InvalidFileException("Error encountered while copying \"%s\" to \"%s\":\n%s"%(srcfile,myfile,str(e)))
         else:
             print("Warning: the file \""+srcfile+"\" of "+objtype+" \""+objname+"\" does not exist!",file=sys.stderr)
@@ -642,7 +644,7 @@ def importfromdir(location,objtype=None,objnamelist=None,dryrun=None,version=Non
     importall=0
     typeobjdict=utils.traverseobjdir(location)
     if typeobjdict:
-        objtypeindir=typeobjdict.keys()[0]
+        objtypeindir=list(typeobjdict.keys())[0]
         objnamesindir=typeobjdict[objtypeindir]
         if objtype is None:
             objtype=objtypeindir
@@ -665,7 +667,7 @@ def importfromdir(location,objtype=None,objnamelist=None,dryrun=None,version=Non
             if importall:
                 try:
                     importobjdir(objdir,dryrun,version,update,dbsession,envs,objtype)
-                except ObjTypeNonExistException,e:
+                except ObjTypeNonExistException:
                        raise ObjTypeNonExistException("cannot find \"%s\" type objects in directory \"%s\""%(objtype,objtype))
             else:
                 importobjdir(objdir,dryrun,version,update,dbsession,envs,objtype)
@@ -700,7 +702,7 @@ def importobj(srcfile,srcdir,objtype,objnames=None,dryrun=None,version=None,upda
                 f = open(env_file)
                 vardict.update( yaml.load(f) )
                 f.close()
-            except Exception,e:
+            except Exception:
                 raise InvalidFileException("Error: Failed to load variable file '%s', please check ..." % env_file)
 
      if envs:
@@ -765,7 +767,7 @@ def importobj(srcfile,srcdir,objtype,objnames=None,dryrun=None,version=None,upda
                              #import current object
                              try:
                                  importobjdir(srcdir,dryrun,version,update,dbsession,envs,myobjtype)
-                             except ObjTypeNonExistException,e:
+                             except ObjTypeNonExistException as e:
                                  if importallobjtypes:
                                      print(str(e),file=sys.stderr)
                                      continue
@@ -776,7 +778,7 @@ def importobj(srcfile,srcdir,objtype,objnames=None,dryrun=None,version=None,upda
                          try:
                              #this is an obj inventory directory for a objtype
                              importfromdir(srcdir,myobjtype,objnamelist,dryrun,version,update,dbsession,envs=envs)
-                         except ObjTypeNonExistException,e:
+                         except ObjTypeNonExistException as e:
                              if importallobjtypes:
                                  print(str(e),file=sys.stderr)
                                  continue

--- a/xcat-inventory/xcclient/inventory/shell.py
+++ b/xcat-inventory/xcclient/inventory/shell.py
@@ -10,18 +10,19 @@ Command-line interface to xCAT inventory import/export
 """
 
 from __future__ import print_function
-from xcclient import shell
-from exceptions import *
-import backend
+
 import re
 import sys
 import traceback
-import os
-import utils
+
+from xcclient import shell
+from .exceptions import *
+from . import backend, utils
+
 
 try: 
     import xcclient.inventory.manager as mgr
-except ImportError,e:
+except ImportError as e:
      if re.match(r'No module named pymysql',str(e),re.I):
          print(r'Error: '+str(e), file=sys.stderr)
          print(r"Please install package 'python-PyMySQL-0.7.x' or 'PyMySQL 0.7.x' on PyPI",file=sys.stderr)
@@ -71,7 +72,7 @@ class InventoryShell(shell.ClusterShell):
             mybackend=backend.Invbackend()
             mybackend.diff()
         else:
-            from inventorydiff import InventoryDiff
+            from .inventorydiff import InventoryDiff
             InventoryDiff(args).inventory_diff()
 
     def do_envlist(self,args):
@@ -157,7 +158,8 @@ class InventoryShell(shell.ClusterShell):
         """tell me where i am, which branch,which revision. shortcut:\"w\""""
         mybackend=backend.Invbackend()
         mybackend.whereami()
-    
+
+
 # main entry for CLI
 def main():
     utils.initglobal()
@@ -166,7 +168,7 @@ def main():
     except KeyboardInterrupt:
         print("... terminating xCAT inventory management tool", file=sys.stderr)
         sys.exit(2)
-    except (InvalidFileException,ObjNonExistException,CommandException,InvalidValueException,BadDBHdlException,BadSchemaException,DBException,ParseException,InternalException,ObjTypeNonExistException,FileNotExistException,BackendNotInitException,ShErrorReturnException,DirNotExistException), e:
+    except (InvalidFileException,ObjNonExistException,CommandException,InvalidValueException,BadDBHdlException,BadSchemaException,DBException,ParseException,InternalException,ObjTypeNonExistException,FileNotExistException,BackendNotInitException,ShErrorReturnException,DirNotExistException) as e:
         print(str(e), file=sys.stderr)
         sys.exit(1)
     #except (ParserError), e:

--- a/xcat-inventory/xcclient/inventory/structurediff.py
+++ b/xcat-inventory/xcclient/inventory/structurediff.py
@@ -2,11 +2,12 @@
 
 from __future__ import print_function
 import deepdiff
-from utils import *
+
 import yaml
 import json
-import sys
 import re
+
+from .utils import *
 
 class format_diff_output(object):
     def __init__(self):

--- a/xcat-inventory/xcclient/inventory/utils.py
+++ b/xcat-inventory/xcclient/inventory/utils.py
@@ -149,13 +149,15 @@ def initglobal():
 # if "key" of d1 or "key" of d1[key] not in d2, delete it
 def filter_dict_keys(d1, d2):
     tmp_d1 = d1
-    for key in tmp_d1.keys():
+    tmp_d1_keys = list(tmp_d1.keys())
+    for key in tmp_d1_keys:
         if key not in d2:
             del tmp_d1[key]
             continue
         if type(tmp_d1[key]) != dict:
             continue
-        for subkey in tmp_d1[key].keys():
+        tmp_d1_v_keys = list(tmp_d1[key].keys())
+        for subkey in tmp_d1_v_keys:
             if subkey not in d2[key]:
                 del tmp_d1[key][subkey]
     return tmp_d1

--- a/xcat-inventory/xcclient/inventory/utils.py
+++ b/xcat-inventory/xcclient/inventory/utils.py
@@ -11,6 +11,10 @@ import re
 import subprocess
 import json
 import yaml
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
 from contextlib import contextmanager
 
 from . import globalvars
@@ -120,7 +124,7 @@ def loadfile(filename):
             contents=json.loads(f)
         except ValueError:
             try:
-                contents = yaml.load(f, Loader=yaml.FullLoader)
+                contents = yaml.load(f, Loader=Loader)
             except Exception:
                 raise InvalidFileException("Error: failed to load file \"%s\", please validate the file with 'yamllint %s'(for yaml format) or 'cat %s|python -mjson.tool'(for json format)!"%(filename,filename,filename))
         return contents, fmt

--- a/xcat-inventory/xcclient/inventory/utils.py
+++ b/xcat-inventory/xcclient/inventory/utils.py
@@ -44,7 +44,8 @@ def runCommand(cmd, env=None):
 
 #remove the dict entries whose value is null or ''
 def Util_rmnullindict(mydict):
-    for key in mydict.keys():
+    key_list = list(mydict.keys())
+    for key in key_list:
         if isinstance(mydict[key],dict):
             Util_rmnullindict(mydict[key])
             if not mydict[key].keys():

--- a/xcat-inventory/xcclient/inventory/vutil.py
+++ b/xcat-inventory/xcclient/inventory/vutil.py
@@ -8,12 +8,10 @@
 
 from __future__ import print_function
 import os
-import yaml
-import sys
 import re
-import utils
-import globalvars
 from distutils.version import LooseVersion, StrictVersion
+
+from . import globalvars
 
 def isIPaddr(varin):
     ValidIpAddressRegex = "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.(([0-9]|[0-9]{2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){2}([0-9]|[0-9]{2}|0[0-9]{2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])$";

--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -238,10 +238,10 @@ class XcatBase(object):
         result=evalexp()
         if myschmpath:
             if sys.version_info < (3,0):
-                equal = bool(cmp(result,tabcol))
+                equal = bool(0 == cmp(result,tabcol))
             else:
                 result = result or ''
-                equal = bool((result > tabcol) - (result < tabcol))
+                equal = bool(0 == (result > tabcol) - (result < tabcol))
             if equal :
                 value=Util_getdictval(self._mydict,myschmpath)
                 self._dbhash[tabcol]=value

--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -6,6 +6,7 @@
 #
 import yaml
 
+import sys
 import re
 from copy import *
 
@@ -236,8 +237,12 @@ class XcatBase(object):
         evalexp=eval("lambda "+myexpression,None,ctxdict)
         result=evalexp()
         if myschmpath:
-            #if 0==cmp(result,tabcol):
-            if 0 == (result > tabcol) - (result < tabcol):
+            if sys.version_info < (3,0):
+                equal = bool(cmp(result,tabcol))
+            else:
+                result = result or ''
+                equal = bool((result > tabcol) - (result < tabcol))
+            if equal :
                 value=Util_getdictval(self._mydict,myschmpath)
                 self._dbhash[tabcol]=value
             else:
@@ -375,7 +380,7 @@ class XcatBase(object):
                    invalidkeylist.append(curpath)
                    return
                for key in objdict.keys():
-                   if schemadict.has_key(key):
+                   if key in schemadict:
                        _dictcmp(schemadict[key],objdict[key],invalidkeylist,curpath+'.'+key)
                    else:
                        invalidkeylist.append(curpath+'.'+key)

--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -304,7 +304,7 @@ class XcatBase(object):
             schema=cls._schema
         else:
             try:
-                schemacontent = yaml.load(open(schemapath, 'r'), Loader=yaml.FullLoader)
+                schemacontent = yaml.load(open(schemapath, 'r'), Loader=Loader)
             except Exception as e:
                 raise BadSchemaException("Error: Invalid schema file \"%s\": %s" % (schemapath, e))
             schmkey=list(schemacontent.keys())[0]
@@ -342,7 +342,7 @@ class XcatBase(object):
             schema=cls._schema_loc__
         #cls._schema=yaml.load(open(schema,'r'))['node']
         try: 
-            schemacontent=yaml.load(open(schema, 'r'), Loader=yaml.FullLoader)
+            schemacontent=yaml.load(open(schema, 'r'), Loader=Loader)
         except Exception as e:
             raise BadSchemaException("Error: Invalid schema file \"%s\": %s" % (schema, e))
         schmkey=list(schemacontent.keys())[0]

--- a/xcat-inventory/xcclient/shell.py
+++ b/xcat-inventory/xcclient/shell.py
@@ -13,12 +13,10 @@ Command-line interface skeleton to xCAT
 from __future__ import print_function
 import argparse
 import logging
-import os
-import sys
-import six
+
 import re
-import inventory.exceptions 
-import inventory.globalvars
+from .inventory import exceptions as exp
+from .inventory import globalvars
 
 # Decorator to define CLI args
 def arg(*args, **kwargs):
@@ -161,7 +159,7 @@ class ClusterShell(object):
             if args.command in self.subcommands:
                 self.subcommands[args.command].print_help()
             else:
-                raise inventory.exceptions.CommandException("Error: '%s' is not a valid subcommand" %
+                raise exp.CommandException("Error: '%s' is not a valid subcommand" %
                                        args.command)
         else:
             self.parser.print_help()
@@ -170,7 +168,7 @@ class ClusterShell(object):
         # Parse args once to find version
         parser = self.get_common_parser(description)
         (options, args) = parser.parse_known_args(argv)
-        inventory.globalvars.verbose=options.verbose     
+        globalvars.verbose=options.verbose
         self.setup_debugging(options.debug)
 
         # build available subcommands based on version
@@ -189,7 +187,7 @@ class ClusterShell(object):
 
         if args[0] not in self.subcommands.keys():
             self.do_help(options)
-            raise inventory.exceptions.CommandException("Error: not a valid subcommand to run")
+            raise exp.CommandException("Error: not a valid subcommand to run")
 
         if '-h' in argv or '--help' in argv:
             args.append('-h')


### PR DESCRIPTION
Trigger CI on master branch, and CI could ensure python2 is working.

UT it on a python3 environtment:
```
python --version
Python 3.5.2

And need to workaround /opt/xcat/share/xcat/tools/autotest/testcase/xcat_inventory/validatehelper to use /usr/bin/python2

sudo bash -c '. /etc/profile.d/xcat.sh &&  xcattest -f /root/xcat.conf -s inventory_ci > /tmp/mylog1'

grep END /tmp/mylog1|grep Failed
------END::xcat_inventory_diff_files_filename::Failed::Time:Wed May  8 05:56:36 2019 ::Duration::1 sec------
------END::backend::Failed::Time:Wed May  8 06:17:57 2019 ::Duration::360 sec------
------END::xcat_inventory_diff_source::Failed::Time:Wed May  8 06:20:11 2019 ::Duration::10 sec------
------END::xcat_inventory_diff_files::Failed::Time:Wed May  8 06:27:01 2019 ::Duration::1 sec------

```

The failed cases is caused by the python3, but the hard code in test cases.