### PR TITLE
rinstall RESTful API

### DIFF
--- a/xcat-inventory/xcclient/allien/resources/__init__.py
+++ b/xcat-inventory/xcclient/allien/resources/__init__.py
@@ -35,6 +35,9 @@ api.add_namespace(api_setting_ns)
 from .security import ns as api_security_ns
 api.add_namespace(api_security_ns)
 
+from .service import ns as api_manager_ns
+api.add_namespace(api_manager_ns)
+
 #from .nodehm import *
 #api.add_resource(PowerResource, '/node/<string:id>/power')
 #api.add_resource(PowerRangeResource, '/power')

--- a/xcat-inventory/xcclient/allien/resources/network.py
+++ b/xcat-inventory/xcclient/allien/resources/network.py
@@ -6,19 +6,16 @@
 
 from flask import request, current_app
 from flask_restplus import Resource, Namespace, fields, reqparse
-from xcclient.xcatd import XCATClient, XCATClientParams
+
 from xcclient.xcatd.client.xcat_exceptions import XCATClientError
+
 from ..invmanager import get_inventory_by_type, upd_inventory_by_type, del_inventory_by_type, transform_from_inv, transform_to_inv, validate_resource_input_data, patch_inventory_by_type
 from ..invmanager import InvalidValueException, ParseException
-from .inventory import ns, resource
+from .inventory import ns, resource, patch_action
 
 """
 These APIs is to handle networking related resources: subnet, route.
 """
-
-patch_action = ns.model('modify', {
-    'modify': fields.Raw(description='The update attr and value info of resource', required=True)
-})
 
 
 @ns.route('/subnets')
@@ -131,7 +128,6 @@ class RouteResource(Resource):
             ns.abort(400, str(e))
 
         return None, 200
-
 
     @ns.expect(resource)
     def put(self, name):

--- a/xcat-inventory/xcclient/allien/resources/node.py
+++ b/xcat-inventory/xcclient/allien/resources/node.py
@@ -35,10 +35,6 @@ actionreq = ns.model('ActionReq', {
 })
 
 
-SUPPORTED_OPERATIONS = {
-    'rinstall': _rinstall
-}
-
 @ns.route('/nodes')
 class NodeListResource(Resource):
 
@@ -76,14 +72,9 @@ class NodeInventoryResource(Resource):
         return get_node_inventory('node', node)
 
 
-def _rinstall(node, spec=None):
-    """Helper method to parse payload and do rintall"""
-
-    boot_state = 'osimage'
-    if 'boot_state' in spec:
-        boot_state = spec['boot_state']
-
-    provision(node, target=boot_state)
+SUPPORTED_OPERATIONS = {
+    'rinstall': provision
+}
 
 
 @ns.route('/nodes/<node>/_operation')
@@ -109,5 +100,5 @@ class NodeOperationResource(Resource):
         except XCATClientError as e:
             ns.abort(500, str(e))
 
-        current_app.logger.debug("outputs=%s" % result.output_msgs)
+        current_app.logger.debug("outputs=%s" % result)
         return 'Success'

--- a/xcat-inventory/xcclient/allien/resources/osimage.py
+++ b/xcat-inventory/xcclient/allien/resources/osimage.py
@@ -6,19 +6,17 @@
 import os
 from flask import request, current_app
 from flask_restplus import Resource, Namespace, fields, reqparse
+
 from xcclient.xcatd import XCATClient, XCATClientParams
 from xcclient.xcatd.client.xcat_exceptions import XCATClientError
+
 from ..invmanager import get_inventory_by_type, upd_inventory_by_type, del_inventory_by_type, transform_from_inv, transform_to_inv, validate_resource_input_data, patch_inventory_by_type
 from ..invmanager import InvalidValueException, ParseException
-from .inventory import ns, resource
+from .inventory import ns, resource, patch_action
 
 """
 These APIs is to handle Image related resources: osimage, osdistro,.
 """
-
-patch_action = ns.model('modify', {
-    'modify': fields.Raw(description='The update attr and value info of resource', required=True)
-})
 
 
 @ns.route('/osimages')
@@ -43,6 +41,7 @@ class OSimageListResource(Resource):
             ns.abort(400, e.message)
 
         return None, 201
+
 
 @ns.route('/osimages/<string:name>')
 @ns.response(404, 'OSimage not found.')
@@ -119,7 +118,8 @@ class DistroListResource(Resource):
         except (InvalidValueException, XCATClientError) as e:
             ns.abort(400, str(e))
         return None, 201
-    
+
+
 @ns.route('/distros/<string:name>')
 @ns.response(404, 'Distro not found.')
 class DistroResource(Resource):

--- a/xcat-inventory/xcclient/allien/resources/service.py
+++ b/xcat-inventory/xcclient/allien/resources/service.py
@@ -15,8 +15,7 @@ from ..srvmanager import provision
 ns = Namespace('manager', description='Manage services and tasks')
 srvreq = ns.model('SvrReq', {
     'noderange': fields.String(description='The nodes or groups to be operated', required=True),
-    'boot_state': fields.String(description='The specified operation', required=False),
-    'boot_param': fields.Raw(description='The optional parameters of the operation', required=False)
+    'action_spec': fields.Raw(description='The optional parameters of the operation', required=False)
 })
 
 
@@ -40,15 +39,14 @@ class ProvisionResource(Resource):
 
         # Now just invode `rinstall` to xcatd
         data = request.get_json()
-        boot_state = data.get('boot_state')
-        if data.get('boot_param'):
-            current_app.logger.debug("boot_param=%s" % data.get('boot_param'))
+        if data.get('action_spec'):
+            current_app.logger.debug("action_spec=%s" % data.get('action_spec'))
 
         try:
-            result = provision(data['noderange'], target=boot_state)
+            result = provision(data['noderange'], data.get('action_spec'))
         except XCATClientError as e:
             ns.abort(500, str(e))
 
         # TODO: a reasonable response for each nodes, now just return xcatd output
-        return dict(outputs=result.output_msgs)
+        return dict(outputs=result)
 

--- a/xcat-inventory/xcclient/allien/resources/service.py
+++ b/xcat-inventory/xcclient/allien/resources/service.py
@@ -1,0 +1,55 @@
+###############################################################################
+# IBM(c) 2019 EPL license http://www.eclipse.org/legal/epl-v10.html
+###############################################################################
+
+# -*- coding: utf-8 -*-
+
+import os
+from flask import request, current_app
+from flask_restplus import Namespace, Resource, reqparse, fields
+
+from xcclient.xcatd import XCATClient, XCATClientParams
+from xcclient.xcatd.client.xcat_exceptions import XCATClientError
+
+ns = Namespace('manager', description='Manage services and tasks')
+srvreq = ns.model('SvrReq', {
+    'noderange': fields.String(description='The nodes or groups to be operated', required=True),
+    'boot_state': fields.String(description='The specified operation', required=False),
+    'boot_param': fields.Raw(description='The optional parameters of the operation', required=False)
+})
+
+
+@ns.route('/provision')
+class ProvisionResource(Resource):
+
+    @ns.doc('list_provision')
+    def get(self):
+        """List all provision tasks"""
+        # TODO: it should be supported by new install monitor daemon
+
+        # Just return mock data now
+        return []
+
+    @ns.expect(srvreq)
+    @ns.doc('create_provision')
+    def post(self):
+        """Create a provision task for nodes"""
+        # TODO: Long term, it need a task id for each created provision task
+        #       And tracked in the install monitor daemon.
+
+        # Now just invode `rinstall` to xcatd
+        data = request.get_json()
+        boot_state = data.get('boot_state')
+        if data.get('boot_param'):
+            current_app.logger.debug("boot_param=%s" % data.get('boot_param'))
+
+        param = XCATClientParams(xcatmaster=os.environ.get('XCAT_SERVER'))
+        cl = XCATClient()
+        cl.init(current_app.logger, param)
+        try:
+            result = cl.rinstall(noderange=data['noderange'], boot_state=boot_state)
+        except XCATClientError as e:
+            ns.abort(500, str(e))
+
+        return dict(outputs=result.output_msgs)
+

--- a/xcat-inventory/xcclient/allien/srvmanager.py
+++ b/xcat-inventory/xcclient/allien/srvmanager.py
@@ -9,12 +9,28 @@ from flask import g, current_app
 
 from xcclient.xcatd import XCATClient, XCATClientParams
 
+from .invmanager import ParseException
 
-def provision(nr, target='osimage', param=None):
-    """provision nodes"""
+
+def provision(nr, action_spec=None):
+    """Helper method to parse payload and do rintall"""
+
+    boot_state = 'osimage'
+    target =  None
+    if action_spec:
+        if 'osimage' in action_spec and action_spec.get('osimage'):
+            target = "osimage=%s" % action_spec['osimage']
+
+        if 'boot_state' in action_spec and target:
+            raise ParseException('Do not specify multiple boot target.')
+        elif not target:
+            target = action_spec.get('boot_state')
+
+    boot_state = target or boot_state
+    # TODO: support more args later
 
     param = XCATClientParams(xcatmaster=os.environ.get('XCAT_SERVER'))
     cl = XCATClient()
     cl.init(current_app.logger, param)
-    result = cl.rinstall(noderange=nr, boot_state=target)
+    result = cl.rinstall(noderange=nr, boot_state=boot_state)
     return result.output_msgs

--- a/xcat-inventory/xcclient/allien/srvmanager.py
+++ b/xcat-inventory/xcclient/allien/srvmanager.py
@@ -1,0 +1,20 @@
+###############################################################################
+# IBM(c) 2019 EPL license http://www.eclipse.org/legal/epl-v10.html
+###############################################################################
+
+# -*- coding: utf-8 -*-
+
+import os
+from flask import g, current_app
+
+from xcclient.xcatd import XCATClient, XCATClientParams
+
+
+def provision(nr, target='osimage', param=None):
+    """provision nodes"""
+
+    param = XCATClientParams(xcatmaster=os.environ.get('XCAT_SERVER'))
+    cl = XCATClient()
+    cl.init(current_app.logger, param)
+    result = cl.rinstall(noderange=nr, boot_state=target)
+    return result.output_msgs

--- a/xcat-inventory/xcclient/xcatd/client/xcat_cmd_helpers.py
+++ b/xcat-inventory/xcclient/xcatd/client/xcat_cmd_helpers.py
@@ -81,6 +81,34 @@ class GetNodesAttribsHelper(object):
         return parser.parse()
 
 #
+# rinstall commands
+#
+
+
+class RinstallHelper(object):
+    """Helper class for rinstall command"""
+
+    def __init__(self, noderange, boot_state):
+        self.command = 'rinstall'
+        self.noderange = noderange
+        self.boot_state = boot_state
+
+    def __str__(self):
+        return '%s: noderange=%s, boot_state=%s' % \
+            (self.command, self.noderange, self.boot_state)
+
+    def get_request(self):
+        return XCATRequest(command=self.command,
+                           noderange=self.noderange,
+                           args=[self.boot_state])
+
+    def parse_response(self, ssl_client):
+        req = self.get_request()
+        parser = XCATGenericCmdResultParser(req, ssl_client, output_msg_tags=['info'])
+        return parser.parse()
+
+
+#
 # Node commands
 #
 
@@ -166,6 +194,7 @@ class RmdefHelper(GenericCmdHelper):
         parser = XCATGenericCmdResultParser(req, ssl_client, output_msg_tags=['info'])
         return parser.parse()
 
+
 class CopycdsHelper(GenericCmdHelper):
     """Helper class for copycds command"""
 
@@ -180,6 +209,7 @@ class CopycdsHelper(GenericCmdHelper):
 #
 # make* commands
 #
+
 
 class MakedhcpHelper(GenericCmdHelper):
     """Helper class for makedhcp command"""
@@ -214,11 +244,11 @@ class MakeknownhostsHelper(GenericCmdHelper):
         GenericCmdHelper.__init__(self, 'makeknownhosts', noderange, args)
 
 
-class MakeconservercfHelper(GenericCmdHelper):
-    """Helper class for makeconservercf command"""
+class MakeconsoleHelper(GenericCmdHelper):
+    """Helper class for makegocons command"""
 
     def __init__(self, noderange, args):
-        GenericCmdHelper.__init__(self, 'makeconservercf', noderange, args)
+        GenericCmdHelper.__init__(self, 'makegocons', noderange, args)
 
 
 class MknbHelper(GenericCmdHelper):

--- a/xcat-inventory/xcclient/xcatd/xcat_client.py
+++ b/xcat-inventory/xcclient/xcatd/xcat_client.py
@@ -165,6 +165,29 @@ class XCATClient(XCATClientBase):
     # Node commands
     #
 
+
+    def rinstall(self, noderange, boot_state):
+        """Install to boot state for a noderange
+        Params:
+            noderange: xCAT noderange expression (str)
+            boot_state:  Node boot state, e.g., boot, install, etc. (str)
+        Returns:
+            XCATGenericCmdResult  (see client/xcat_data.py)
+        Exceptions:
+            XCATClientError  (see client/xcat_exceptions.py)
+        """
+        try:
+            self._logger.trace('Entering')
+            t = Timer().start_timer()
+            return self._run_command(RinstallHelper(noderange, boot_state))
+        finally:
+            t.stop_timer()
+            self._logger.perf('%s msec' % t.get_elapsed_in_msec())
+            self._logger.trace('Leaving')
+
+
+
+
     def nodeset(self, noderange, boot_state):
         """Sets the boot state for a noderange
         Params:
@@ -393,7 +416,7 @@ class XCATClient(XCATClientBase):
             self._logger.trace('Leaving')
 
 
-    def makeconservercf(self, noderange, args=[]):
+    def makeconsole(self, noderange, args=[]):
         """Generates the conserver configuration file from info in 
         in xCAT tables.
         Params:
@@ -407,7 +430,7 @@ class XCATClient(XCATClientBase):
         try:
             self._logger.trace('Entering')
             t = Timer().start_timer()
-            return self._run_command(MakeconservercfHelper(noderange, args))
+            return self._run_command(MakeconsoleHelper(noderange, args))
         finally:
             t.stop_timer()
             self._logger.perf('%s msec' % t.get_elapsed_in_msec())


### PR DESCRIPTION
This PR is for https://github.ibm.com/xcat2/task_management/issues/136, and below changes included:
- `rinstall` python client to xcatd for `rinstall`
- `mkconsole` python client to xcatd for `makegocons`
- single node provision API with POST `/system/nodes/{node}/_operation`
- multiple nodes provision API with POST `/manager/provision`
