### PR TITLE
add secrets api and inventary table update

### DIFF
--- a/xcat-inventory/xcclient/allien/invmanager.py
+++ b/xcat-inventory/xcclient/allien/invmanager.py
@@ -174,6 +174,11 @@ def add_table_entry_by_key(objtype, obj_attr_dict):
     hdl.addTabEntrybykey(objtype, obj_attr_dict)
     dbsession.commit()
 
+def update_table_entry_by_key(objtype, obj_attr_dict):
+    hdl = InventoryFactory.createHandler(objtype, dbsession, None)
+    hdl.updateTabEntrybykey(objtype, obj_attr_dict)
+    dbsession.commit()
+
 def del_inventory_by_type(objtype, obj_list):
     """delete objects from data store"""
     # hdl = InventoryFactory.createHandler(objtype, dbsession, None)

--- a/xcat-inventory/xcclient/allien/resources/security.py
+++ b/xcat-inventory/xcclient/allien/resources/security.py
@@ -104,14 +104,14 @@ class SecretsListResource(Resource):
             if not data.get('kind'):
                 raise InvalidValueException("kind of the secret is mandatory")
 
-            passwd_dict={u"key":data.get('kind')}
+            passwd_dict={"key":data.get('kind')}
             passwd_dict.update(data.get('spec'))
             add_table_entry_by_key('passwd', passwd_dict)
         except (InvalidValueException, ParseException, DBException) as e:
             ns.abort(400, e.message)
         id=''
-        if passwd_dict.has_key('username'):
-            id=passwd_dict['key']+'_'+passwd_dict['username']
+        if 'username' in passwd_dict.keys():
+            id='%s_%s' % (passwd_dict['key'],passwd_dict['username'])
         else:
             id=passwd_dict['key']
         result={"message":"new user is created.", "id":id}
@@ -166,7 +166,7 @@ class SecretsResource(Resource):
 
     @ns.expect(sec_post_resource)
     def post(self, id):
-        """modify a passwd object"""
+        """modify a secret object"""
         data = request.get_json()
         try:
 
@@ -177,7 +177,7 @@ class SecretsResource(Resource):
             if data.get('spec')['username'] != username :
                 raise InvalidValueException("It is not the same user.")
 
-            passwd_dict={u"key":kind}
+            passwd_dict={"key":kind}
             passwd_dict.update(data.get('spec'))
             update_table_entry_by_key('passwd', passwd_dict)
         except (InvalidValueException, ParseException) as e:

--- a/xcat-inventory/xcclient/inventory/dbfactory.py
+++ b/xcat-inventory/xcclient/inventory/dbfactory.py
@@ -351,14 +351,33 @@ class dbfactory():
             raise DBException("Error: no find table "+str(tab)+": "+str(e))
         tabkeys=tabcls.primkeys()
         try:
-            query=session.query(tabcls)
+            dbsession=self._dbsession.loadSession(tab)
+            query=dbsession.query(tabcls)
             for tabkey in tabkeys:
                 query=query.filter(getattr(tabcls,tabkey) == objdict[tabkey])
             record=query.all()
             if record:
-                raise DBException("Error: "+record+" exist")
+                raise DBException("this user exist")
             else:
-                query.update(objdict)
+                dbsession.execute(tabcls.__table__.insert(), objdict)
+        except Exception as e:
+            raise DBException("Error: "+str(tab)+": "+str(e))
+
+    
+    def updatetabentries(self,tab,objdict):
+        if hasattr(dbobject,tab):
+            tabcls=getattr(dbobject,tab)
+        else:
+            raise DBException("Error: no find table "+str(tab)+": "+str(e))
+        tabkeys=tabcls.primkeys()
+        try:
+            dbsession=self._dbsession.loadSession(tab)
+            query=dbsession.query(tabcls)
+            wherecl=''
+            for tabkey in tabkeys:
+                query=query.filter(getattr(tabcls,tabkey) == objdict[tabkey])
+                del objdict[tabkey]
+            query.update(objdict)
         except Exception as e:
             raise DBException("Error: "+str(tab)+": "+str(e))
 

--- a/xcat-inventory/xcclient/inventory/manager.py
+++ b/xcat-inventory/xcclient/inventory/manager.py
@@ -271,6 +271,9 @@ class InventoryFactory(object):
     def addTabEntrybykey(self, table, obj_attr_dict):
         self.getDBInst().addtabentries(table, obj_attr_dict)
 
+    def updateTabEntrybykey(self, table, obj_attr_dict):
+        self.getDBInst().updatetabentries(table, obj_attr_dict)
+
     def deleteTabEntrybykey(self, table, obj_attr_dict):
         self.getDBInst().deltabentries(table, obj_attr_dict)
     


### PR DESCRIPTION
For
https://github.ibm.com/xcat2/task_management/issues/145

Description:
1. add updating and adding xCAT table entry in xcat-inventory
2. add secrets post API

UT:
1. 
/inventory/secrets | POST | create a new secret object |  
-- | -- | -- | --
```
curl -X POST "http://10.4.41.7:5000/api/v2/security/secrets" -H  "accept: application/json" -H  "Content-Type: application/json" -d "{    \"kind\": \"test\",    \"spec\": {      \"username\": \"xc\",      \"password\": \"cluster\"    }}"
{
  "message": "new user is created.",
  "id": "test_xc"
}
```
2. 
/inventory/secrets/{id} | POST | modify a specified type of secrets object |  
-- | -- | -- | --
```
curl -X POST "http://10.4.41.7:5000/api/v2/security/secrets/test_xcx" -H  "accept: application/json" -H  "Content-Type: application/json" -d "{    \"kind\": \"test\",    \"spec\": {      \"username\": \"x\",      \"password\": \"aaabbbbb\"    }}"
{
  "message": "It is not the same user."
}

curl -X POST "http://10.4.41.7:5000/api/v2/security/secrets/test_x" -H  "accept: application/json" -H  "Content-Type: application/json" -d "{    \"kind\": \"test\",    \"spec\": {      \"username\": \"x\",      \"password\": \"aaxxxkkkkn\"    }}"
{
  "message": "Update user test_x successfully."
}
```


  