### PR TITLE
default node details API implementation when site.hierarchicalattrs is empty

### DIFF
--- a/xcat-inventory/xcclient/allien/invmanager.py
+++ b/xcat-inventory/xcclient/allien/invmanager.py
@@ -131,13 +131,16 @@ def get_hmi_by_list(nodelist=None):
     return result
 
 def dict_merge(dct, merge_dct):
-    """ Recursive dict merge. Inspired by :meth:``dict.update()``, instead of
-    updating only top-level keys, dict_merge recurses down into dicts nested
-    to an arbitrary depth, updating keys. The ``merge_dct`` is merged into
-    ``dct``.
-    :param dct: dict onto which the merge is executed
-    :param merge_dct: dct merged into dct
-    :return: None
+    """Recursive dict merge
+
+    Recurse down into dicts nested to an arbitrary depth, updating keys. The merge_dct is merged into dct.
+
+    Args:
+        dct: dict onto which the merge is executed
+        merge_dct: dct merged into dct
+
+    Returns:
+        None
     """
     for k, v in merge_dct.iteritems():
         if (k in dct and isinstance(dct[k], dict)
@@ -148,6 +151,20 @@ def dict_merge(dct, merge_dct):
     return dct
 
 def get_node_attributes(node):
+    """Get node attbributes.
+
+    Args:
+        node: one node name
+
+    Returns:
+        example:
+
+           {
+               'meta':{"name":"node1"},
+               'spec':{"obj_type": "node",
+                      ... ... }
+           }
+    """
     # get hierarchicalattrs from site table
     hierarchicalattrs = dbi.getsitetabentries(['hierarchicalattrs'])
     target_node = get_nodes_list(node)
@@ -169,12 +186,28 @@ def get_node_attributes(node):
     return result
 
 def groups_data_overwrite_node(hierarchicalattrs,inv_data={}):
+    """TODO"""
     result={}
     result['meta']='groups_data_overwrite_node'
     return result
 
 def merge_groups_data(inv_data,nodelist):
-    """merge different groups data"""
+    """merge different groups data into dict
+
+    Args:
+        inv_data: all groups inventary data
+        nodelist: ordered group list
+
+    Returns:
+        final group data dict
+
+        example:
+
+            {'obj_type': 'group', 'engines': {'netboot_engine': {'engine_info': {'postbootscripts': 'confignetwork'}}}, 'obj_info': {'grouptype': 'static'}, 'role': 'compute', 'device_type': 'server', 'network_info': 
+          ... ...
+            }}
+
+    """
     mergeddict={}
     for k in list(set(nodelist).intersection(set(inv_data.keys()))):
         if not mergeddict:
@@ -190,6 +223,19 @@ def merge_groups_data(inv_data,nodelist):
     return mergeddict
 
 def merge_xcatdefaults(xcatdefaults_dict,nodedict):
+    """merge xcatdefaults group into nodedict.
+
+    Args:
+        xcatdefaults_dict: xcatdefaults inventory data dict
+        nodedict: node object data dict
+    Returns:
+        new node dict
+        example:
+            {'obj_type': 'node', 
+             'engines': {'netboot_engine': {'engine_info': {'postbootscripts': 'confignetwork'}}}, 'obj_info': {'grouptype': 'static'}, 'role': 'compute', 'device_type': 'server', 'network_info':
+          ... ...
+            }
+    """
     nodepostscripts=''
     scripts=['postbootscripts','postscripts']
     for scp in scripts:
@@ -200,7 +246,22 @@ def merge_xcatdefaults(xcatdefaults_dict,nodedict):
     return nodedict
 
 def fetch_data_from_group(inv_data,node,nodelist):
-    """when site.hierarchicalattrs is empty"""
+    """when site.hierarchicalattrs is empty
+
+    Args:
+        inv_data: node and its groups inventary data
+        node: node name
+        nodelist: ordered node and groups list
+
+    Returns:
+        node object details
+        example:
+            {'meta': {'name':'node1'},
+             'spec': {
+              ... ...
+                }
+            }
+    """
     result={}
     mergeddict={}
     mergeddict=merge_groups_data(inv_data,nodelist)

--- a/xcat-inventory/xcclient/inventory/dbfactory.py
+++ b/xcat-inventory/xcclient/inventory/dbfactory.py
@@ -364,6 +364,18 @@ class dbfactory():
             raise DBException("Error: "+str(tab)+": "+str(e))
 
     def getsitetabentries(self,attrslist=[]):
+        """Fetches rows from site table with specified attributes list.
+
+        Args:
+            attrslist: site table attributes list
+
+        Returns:
+            attributes values
+            example:
+                attributes key and value dict
+        Raises:
+            DBException: An error occurred accessing the database.
+        """
         result={}
         ret={}
         try:

--- a/xcat-inventory/xcclient/inventory/dbfactory.py
+++ b/xcat-inventory/xcclient/inventory/dbfactory.py
@@ -253,7 +253,7 @@ class dbfactory():
             df_matrix=matrixdbfactory(self._dbsession)
             mydict.update(df_matrix.gettab(matrixtabs,keys))
         return mydict
-    
+
     #convert db dict from format {key:{tab.col=value}} to {key:{tab:{col}}}
     def __tabtransform(self,dbdict):
         #print("__tabtransform")
@@ -363,6 +363,24 @@ class dbfactory():
         except Exception as e:
             raise DBException("Error: "+str(tab)+": "+str(e))
 
+    def getsitetabentries(self,attrslist=[]):
+        result={}
+        ret={}
+        try:
+            tabcls=getattr(dbobject,'site')
+            dbsession=self._dbsession.loadSession('site')
+            query=dbsession.query(tabcls)
+            for tkey in attrslist:
+                query=query.filter(getattr(tabcls,'key') == tkey)
+            result=query.all()
+        except Exception as e:
+            raise DBException("Error: "+str(tab)+": "+str(e))
+        if result:
+            for myobj in result:
+                mydict=myobj.getdict()
+                ret.update(mydict)
+        return ret
+
     def updatetabentries(self,tab,objdict):
         if hasattr(dbobject,tab):
             tabcls=getattr(dbobject,tab)
@@ -447,7 +465,7 @@ class dbfactory():
             # Add the specified columns to query
             for c in adjusted_cols:
                 try:
-                    col = getattr(nodelist, c)
+                    col = getattr(tabcls, c)
                     if type(col) is not Col_type:
                         raise AttributeError
 


### PR DESCRIPTION
For https://github.ibm.com/xcat2/task_management/issues/263

PATH | METHOD | Description | Parameters
-- | -- | -- | --
/inventory/node/<nodename>/_detail | GET | get a node object defined in store |  

UT:
```
[root@byrh07 ~]# time curl -X GET "http://10.4.41.7:5000/api/v2/system/nodes/login4/_detail" -H  "accept: application/json"
{
    "meta": {
        "name": "login4"
    },
    "spec": {
        "obj_type": "node",
        "engines": {
            "netboot_engine": {
                "engine_info": {
                    "postbootscripts": "otherpkgs,",
                    "chain": "runcmd=bmcsetup,osimage=compute",
                    "osimage": "login",
                    "postscripts": "syslog,remoteshell,syncfiles,confignetwork -s,setroute,nvidia-exclusive-mode,puppet_agent,gpfsclient,enablekdump"
                },
                "engine_type": "petitboot"
            },
            "hardware_mgt_engine": {
                "engine_type": "openbmc"
            },
            "console_engine": {
                "engine_type": "openbmc"
            },
            "power_mgt_engine": {
                "engine_info": {
                    "pdu": "c24pdu1:2,c24pdu2:2"
                }
            }
        },
        "device_info": {
            "uuid": "8335-gtc-784d27a-70e28414416a",
            "supportedarchs": "ppc64le",
            "characteristics": "mp",
            "memory": "523484MB",
            "cpucount": "128",
            "disksize": "sda:1863GB,sdb:1863GB",
            "mtm": "8335-GTC",
            "cputype": "POWER9 (raw), altivec supported",
            "serial": "784D27A",
            "arch": "ppc64le"
        },
        "obj_info": {
            "groups": "login,user,inf,frontend"
        },
        "role": "compute",
        "position_info": {
            "rack": "c24",
            "unit": "16"
        },
        "device_type": "server",
        "network_info": {
            "primarynic": {
                "ip": "10.134.0.34",
                "mac": [
                    "00:16:3e:23:26:05!*NOIP*",
                    "00:16:3e:73:4c:7c"
                ]
            },
            "nics": {
                "ib0": {
                    "type": [
                        "Infiniband"
                    ],
                    "hostnamesuffixes": [
                        "ib"
                    ],
                    "networks": [
                        "ipoib"
                    ],
                    "ips": [
                        "10.41.0.34"
                    ]
                },
                "bond0": {
                    "nicdevices": [
                        "enP48p1s0f0",
                        "enP48p1s0f1"
                    ],
                    "type": [
                        "bond"
                    ],
                    "networks": [
                        "public"
                    ],
                    "ips": [
                        "10.219.134.74"
                    ]
                },
                "enP48p1s0f0": {
                    "type": [
                        "Ethernet"
                    ]
                },
                "enP48p1s0f1": {
                    "type": [
                        "Ethernet"
                    ]
                }
            },
            "connections": {
                "switch": "c24eth",
                "switchport": "24"
            },
            "otherinterfaces": "login4bmc:10.134.64.34",
            "routenames": "extgwy,alpinetds"
        }
    }
}

real	0m0.762s
user	0m0.009s
sys	0m0.014s

[root@byrh07 ~]# time lsdef login4
Object name: login4
    arch=ppc64le
    chain=runcmd=bmcsetup,osimage=compute
    cons=openbmc
    cpucount=128
    cputype=POWER9 (raw), altivec supported
    disksize=sda:1863GB,sdb:1863GB
    groups=login,user,inf,frontend
    ip=10.134.0.34
    mac=00:16:3e:23:26:05!*NOIP*|00:16:3e:73:4c:7c
    memory=523484MB
    mgt=openbmc
    mtm=8335-GTC
    netboot=petitboot
    nicdevices.bond0=enP48p1s0f0|enP48p1s0f1
    nichostnamesuffixes.ib0=ib
    nicips.ib0=10.41.0.34
    nicips.bond0=10.219.134.74
    nicnetworks.ib0=ipoib
    nicnetworks.bond0=public
    nictypes.ib0=Infiniband
    nictypes.bond0=bond
    nictypes.enP48p1s0f0=Ethernet
    nictypes.enP48p1s0f1=Ethernet
    nodetype=mp
    otherinterfaces=login4bmc:10.134.64.34
    pdu=c24pdu1:2,c24pdu2:2
    postbootscripts=otherpkgs
    postscripts=syslog,remoteshell,syncfiles,confignetwork -s,setroute,nvidia-exclusive-mode,puppet_agent,gpfsclient,enablekdump
    provmethod=login
    rack=c24
    routenames=extgwy,alpinetds
    serial=784D27A
    supportedarchs=ppc64le
    switch=c24eth
    switchport=24
    unit=16

real	0m2.385s
user	0m0.401s
sys	0m0.129s
```

