### PR TITLE
Status API for specific node

### DIFF
--- a/xcat-inventory/xcclient/allien/srvmanager.py
+++ b/xcat-inventory/xcclient/allien/srvmanager.py
@@ -12,7 +12,7 @@ from flask import g, current_app
 
 from xcclient.xcatd import XCATClient, XCATClientParams
 
-from .invmanager import get_all_nodes, ParseException
+from .invmanager import get_nodes_list, ParseException
 
 
 def provision(nr, action_spec=None):
@@ -39,7 +39,7 @@ def provision(nr, action_spec=None):
     return result.output_msgs
 
 
-MOCK_FREE_POOL = get_all_nodes()
+MOCK_FREE_POOL = get_nodes_list()
 _applied = dict()
 
 


### PR DESCRIPTION
https://github.ibm.com/xcat2/task_management/issues/188

1, replace with the new get_nodes_list method;
2, add path for node status

```
curl http://10.6.27.1:5000/api/v2/system/nodes/mid05tor12cn03/_status
{
    "status": {
        "boot": {
            "state": "powering-on",
            "updated_at": "05-14-2019 01:59:19"
        },
        "sync": {
            "state": "synced",
            "updated_at": "02-13-2019 00:26:52"
        }
    },
    "meta": {
        "name": "mid05tor12cn03"
    }
}
```