### PR TITLE
Update expire time as now+24hours

### DIFF
--- a/xcat-inventory/xcclient/allien/authmanager.py
+++ b/xcat-inventory/xcclient/allien/authmanager.py
@@ -29,7 +29,7 @@ def check_user_token(token_string, username=None, check_expire=True):
         usr = dataset[token_string]['token.username']
         if not username is None and usr != username:
             return 2
-        if not check_expire or time.time() - float(exp) < 86400:
+        if not check_expire or time.time() >= float(exp):
             return 0
         else:
             return 1

--- a/xcat-inventory/xcclient/allien/resources/auth.py
+++ b/xcat-inventory/xcclient/allien/resources/auth.py
@@ -77,7 +77,8 @@ class ToLogin(Resource):
         r, m = check_request_user(request)
         if r == 200: 
             token = uuid.uuid1()
-            expire = time.time()
+            t = time.time()
+            expire = time.time() + 86400
             insert_user_token(g.username, str(token), str(expire))
             return jsonify({'token':{'id': str(token), 'expire': time.strftime("%Y-%m-%d %H:%M:%S",time.localtime(expire))}}) 
         elif not m is None:
@@ -92,7 +93,7 @@ class ToRefresh(Resource):
     def post(self):
         r = check_request_token(request)
         if r == 200:
-            update_user_token(g.auth_token, str(time.time()))
+            update_user_token(g.auth_token, str(time.time() + 86400))
             return "Token refreshed"
         else:
             ns.abort(r)


### PR DESCRIPTION
The expire time is updated as now+24hours
```
[root@briggs01 ~]# docker exec -it ac0717b7d2bd /bin/bash
[root@ac0717b7d2bd xcat-apiserver]# date
Wed May 22 02:50:55 UTC 2019
[root@briggs01 ~]# curl -X POST -H "Content-Type: application/json" -d '{"username":"zet809", "password":"passw0rd"}' http://127.0.0.1:5001/api/v2/auth/login
{
  "token": {
    "expire": "2019-05-23 02:51:00",
    "id": "6e5b7716-7c3c-11e9-b63f-0242ac110002"
  }
}
```