### PR TITLE
Put all APIs using authentication for Security

### DIFF
--- a/xcat-inventory/xcclient/allien/invmanager.py
+++ b/xcat-inventory/xcclient/allien/invmanager.py
@@ -485,7 +485,7 @@ def split_inventory_types(types):
     exclude = ['credential']
 
     # get the include and exclude
-    for rt in types:
+    for rt in types or []:
         rt = rt.strip()
         if not rt:
             raise InvalidValueException("Invalid inventory type name: (%s)" % rt)

--- a/xcat-inventory/xcclient/allien/resources/auth.py
+++ b/xcat-inventory/xcclient/allien/resources/auth.py
@@ -9,8 +9,6 @@ import uuid
 from flask import request, current_app, jsonify, g
 from flask_restplus import Resource, Namespace, fields
 
-#from exceptions import *
-
 from ..authmanager import *
 from . import token_parser
 
@@ -96,8 +94,9 @@ class ToLogin(Resource):
 
 
 @ns.route('/refresh')
+@ns.doc(security='apikey')
 class ToRefresh(Resource):
-    @ns.expect(token_parser)
+
     @ns.response(200, "Token refreshed")
     def post(self):
         r = check_request_token(request)
@@ -109,8 +108,9 @@ class ToRefresh(Resource):
 
 
 @ns.route('/logout')
+@ns.doc(security='apikey')
 class ToLogout(Resource):
-    @ns.expect(token_parser)
+
     @ns.response(200, "Logged out")
     def post(self):
         r = check_request_token_without_account(request)

--- a/xcat-inventory/xcclient/allien/resources/inventory.py
+++ b/xcat-inventory/xcclient/allien/resources/inventory.py
@@ -12,6 +12,7 @@ from flask_restplus import Resource, Namespace, fields, inputs, reqparse
 from xcclient.inventory.manager import export_by_type, importobj
 
 from ..invmanager import InvalidValueException, split_inventory_types
+from . import auth_request
 
 ns = Namespace('inventory', ordered=True, description='Inventory Management')
 
@@ -26,11 +27,14 @@ patch_action = ns.model('modify', {
     'modify': fields.Raw(description='The update attr and value info of resource', required=True)
 })
 
+
 @ns.route('/')
+@ns.doc(security='apikey')
 class InventoryResource(Resource):
 
     @ns.doc('export_inventory')
     @ns.param('types', 'inventory types for exporting')
+    @auth_request
     def get(self):
         """get all inventory defined in store"""
 
@@ -55,6 +59,7 @@ class InventoryResource(Resource):
     @ns.param('clean', 'clean mode. IF specified, all objects other than the ones to import will be removed.')
     @ns.expect(inv_resource)
     @ns.response(201, 'Inventory successfully imported.')
+    @auth_request
     def post(self):
         """import inventory objects"""
 

--- a/xcat-inventory/xcclient/allien/resources/network.py
+++ b/xcat-inventory/xcclient/allien/resources/network.py
@@ -12,6 +12,7 @@ from xcclient.xcatd.client.xcat_exceptions import XCATClientError
 from ..invmanager import get_inventory_by_type, upd_inventory_by_type, del_inventory_by_type, transform_from_inv, transform_to_inv, validate_resource_input_data, patch_inventory_by_type
 from ..invmanager import InvalidValueException, ParseException
 from .inventory import ns, resource, patch_action
+from . import auth_request
 
 """
 These APIs is to handle networking related resources: subnet, route.
@@ -19,8 +20,10 @@ These APIs is to handle networking related resources: subnet, route.
 
 
 @ns.route('/subnets')
+@ns.doc(security='apikey')
 class NetworkListResource(Resource):
 
+    @auth_request
     def get(self):
         """get all the networks defined in store"""
         return transform_from_inv(get_inventory_by_type('network'))
@@ -28,6 +31,7 @@ class NetworkListResource(Resource):
     @ns.doc('create_subnet')
     @ns.expect(resource)
     @ns.response(201, 'Subnet successfully created.')
+    @auth_request
     def post(self):
         """create a network object"""
         data = request.get_json()
@@ -42,9 +46,11 @@ class NetworkListResource(Resource):
 
 
 @ns.route('/subnets/<string:name>')
+@ns.doc(security='apikey')
 @ns.response(404, 'network not found.')
 class NetworkResource(Resource):
 
+    @auth_request
     def get(self, name):
         """get a specified network resource"""
         result = get_inventory_by_type('network', [name])
@@ -53,6 +59,7 @@ class NetworkResource(Resource):
 
         return transform_from_inv(result)[-1]
 
+    @auth_request
     def delete(self, name):
         """delete a specified network resource"""
         try:
@@ -63,6 +70,7 @@ class NetworkResource(Resource):
         return None, 200
 
     @ns.expect(resource)
+    @auth_request
     def put(self, name):
         """replace a specified network resource"""
         data = request.get_json()
@@ -76,6 +84,7 @@ class NetworkResource(Resource):
         return None, 200
 
     @ns.expect(patch_action)
+    @auth_request
     def patch(self, name):
         """Modify a specified network resources"""
         data = request.get_json()
@@ -88,14 +97,17 @@ class NetworkResource(Resource):
 
 
 @ns.route('/routes')
+@ns.doc(security='apikey')
 class RoutesListResource(Resource):
 
+    @auth_request
     def get(self):
         """get all the routes defined in store"""
         return transform_from_inv(get_inventory_by_type('route'))
 
     @ns.expect(resource)
     @ns.response(201, 'Route successfully created.')
+    @auth_request
     def post(self):
         """create a static route """
         data = request.get_json()
@@ -112,6 +124,7 @@ class RoutesListResource(Resource):
 @ns.response(404, 'Route not found.')
 class RouteResource(Resource):
 
+    @auth_request
     def get(self, name):
         """get a specified route in store"""
         result = get_inventory_by_type('route', [name])
@@ -120,6 +133,7 @@ class RouteResource(Resource):
 
         return transform_from_inv(result)[-1]
 
+    @auth_request
     def delete(self, name):
         """delete a specified route """
         try:
@@ -130,6 +144,7 @@ class RouteResource(Resource):
         return None, 200
 
     @ns.expect(resource)
+    @auth_request
     def put(self, name):
         """replace a specified route """
         data = request.get_json()
@@ -142,6 +157,7 @@ class RouteResource(Resource):
         return None, 200
 
     @ns.expect(patch_action)
+    @auth_request
     def patch(self, name):
         """Modify a specified route """
         data = request.get_json()

--- a/xcat-inventory/xcclient/allien/resources/node.py
+++ b/xcat-inventory/xcclient/allien/resources/node.py
@@ -24,6 +24,7 @@ actionreq = ns.model('ActionReq', {
 
 
 @ns.route('/nodes')
+@ns.doc(security='apikey')
 class NodeListResource(Resource):
     
     @ns.doc('list_all_nodes')
@@ -54,6 +55,7 @@ class NodeListResource(Resource):
     @ns.doc('create_node')
     @ns.expect(resource)
     @ns.response(201, 'Node successfully created.')
+    @auth_request
     def post(self):
         """create a node object"""
         data = request.get_json()
@@ -68,9 +70,11 @@ class NodeListResource(Resource):
 
 
 @ns.route('/nodes/<name>')
+@ns.doc(security='apikey')
 class NodeInventoryResource(Resource):
 
     @ns.doc('get_node_inventory')
+    @auth_request
     def get(self, name):
         """get specified node resource"""
 
@@ -82,6 +86,7 @@ class NodeInventoryResource(Resource):
         return transform_from_inv(result)[0]
 
     @ns.doc('delete_node_inventory')
+    @auth_request
     def delete(self, name):
         """delete a node object"""
         try:
@@ -92,6 +97,7 @@ class NodeInventoryResource(Resource):
         return None, 200
 
     @ns.expect(resource)
+    @auth_request
     def put(self, name):
         """replace a node object"""
         data = request.get_json()
@@ -104,6 +110,7 @@ class NodeInventoryResource(Resource):
         return None, 201
 
     @ns.expect(patch_action)
+    @auth_request
     def patch(self, name):
         """Modify a node object"""
         data = request.get_json()
@@ -116,9 +123,11 @@ class NodeInventoryResource(Resource):
 
 
 @ns.route('/nodes/<node>/_status')
+@ns.doc(security='apikey')
 class NodeStatusResource(Resource):
 
     @ns.doc('query node status')
+    @auth_request
     def get(self, node):
 
         dataset = get_nodes_status(node)
@@ -132,8 +141,10 @@ class NodeStatusResource(Resource):
 
 
 @ns.route('/nodes/_detail', '/nodes/<node>/_detail')
+@ns.doc(security='apikey')
 class NodeDetailResource(Resource):
 
+    @auth_request
     def get(self, node=None):
 
         if not node:
@@ -148,6 +159,7 @@ SUPPORTED_OPERATIONS = {
 
 
 @ns.route('/nodes/<node>/_operation')
+@ns.doc(security='apikey')
 class NodeOperationResource(Resource):
 
     @ns.expect(token_parser)

--- a/xcat-inventory/xcclient/allien/resources/osimage.py
+++ b/xcat-inventory/xcclient/allien/resources/osimage.py
@@ -13,6 +13,7 @@ from xcclient.xcatd.client.xcat_exceptions import XCATClientError
 from ..invmanager import get_inventory_by_type, upd_inventory_by_type, del_inventory_by_type, transform_from_inv, transform_to_inv, validate_resource_input_data, patch_inventory_by_type
 from ..invmanager import InvalidValueException, ParseException
 from .inventory import ns, resource, patch_action
+from . import auth_request
 
 """
 These APIs is to handle Image related resources: osimage, osdistro,.
@@ -20,8 +21,10 @@ These APIs is to handle Image related resources: osimage, osdistro,.
 
 
 @ns.route('/osimages')
+@ns.doc(security='apikey')
 class OSimageListResource(Resource):
 
+    @auth_request
     def get(self):
         """get OS image list defined in store"""
         return transform_from_inv(get_inventory_by_type('osimage'))
@@ -29,6 +32,7 @@ class OSimageListResource(Resource):
     @ns.doc('create_osimage')
     @ns.expect(resource)
     @ns.response(201, 'OSimage successfully created.')
+    @auth_request
     def post(self):
         """create an OS image object"""
         data = request.get_json()
@@ -44,9 +48,11 @@ class OSimageListResource(Resource):
 
 
 @ns.route('/osimages/<string:name>')
+@ns.doc(security='apikey')
 @ns.response(404, 'OSimage not found.')
 class OSimageResource(Resource):
 
+    @auth_request
     def get(self, name):
         """get specified OS image resource"""
         result = get_inventory_by_type('osimage', [name])
@@ -55,6 +61,7 @@ class OSimageResource(Resource):
 
         return transform_from_inv(result)[-1]
 
+    @auth_request
     def delete(self, name):
         """delete an OS image object"""
         try:
@@ -65,6 +72,7 @@ class OSimageResource(Resource):
         return None, 200
 
     @ns.expect(resource)
+    @auth_request
     def put(self, name):
         """replace an OS image object"""
         data = request.get_json()
@@ -77,6 +85,7 @@ class OSimageResource(Resource):
         return None, 201
 
     @ns.expect(patch_action)
+    @auth_request
     def patch(self, name):
         """Modify an OS image object"""
         data = request.get_json()
@@ -89,8 +98,10 @@ class OSimageResource(Resource):
 
 
 @ns.route('/distros')
+@ns.doc(security='apikey')
 class DistroListResource(Resource):
 
+    @auth_request
     def get(self):
         """get distro list defined in store"""
         return transform_from_inv(get_inventory_by_type('osdistro'))
@@ -98,6 +109,7 @@ class DistroListResource(Resource):
     @ns.doc('create_distro')
     @ns.param('Image paths', 'Image names')
     @ns.response(201, 'Distro successfully created.')
+    @auth_request
     def post(self):
         """create a distro object"""
         try:
@@ -121,9 +133,11 @@ class DistroListResource(Resource):
 
 
 @ns.route('/distros/<string:name>')
+@ns.doc(security='apikey')
 @ns.response(404, 'Distro not found.')
 class DistroResource(Resource):
 
+    @auth_request
     def get(self, name):
         """get specified distro resource"""
         result = get_inventory_by_type('osdistro', [name])
@@ -132,6 +146,7 @@ class DistroResource(Resource):
 
         return transform_from_inv(result)[-1]
 
+    @auth_request
     def delete(self, name):
         """delete a distro object"""
         # TODO, need to trigger xcatd to clean the ISO directory

--- a/xcat-inventory/xcclient/allien/resources/site.py
+++ b/xcat-inventory/xcclient/allien/resources/site.py
@@ -13,23 +13,30 @@ from xcclient.xcatd import XCATClient, XCATClientParams
 from ..invmanager import get_inventory_by_type, upd_inventory_by_type, transform_from_inv, transform_to_inv
 from ..invmanager import InvalidValueException, ParseException
 from .inventory import resource
+from . import auth_request
 
 ns = Namespace('globalconf', description='System Level Settings')
 
+
 @ns.route('/sites')
+@ns.doc(security='apikey')
 class SitesResource(Resource):
 
     @ns.doc('list_sites')
+    @auth_request
     def get(self):
         """List all site contexts"""
         return transform_from_inv(get_inventory_by_type('site'))
 
+
 @ns.route('/sites/<string:context>')
+@ns.doc(security='apikey')
 @ns.response(404, 'Context not found')
 class SiteResource(Resource):
 
     @ns.doc('get_site')
     @ns.param('attrs', 'Site attribute names')
+    @auth_request
     def get(self, context):
         """Get the attributes of specified context ( only 'clustersite' allowed now )"""
 
@@ -52,6 +59,7 @@ class SiteResource(Resource):
         return {'meta': {'name':context}, 'spec':temp_spec}
 
     @ns.expect(resource)
+    @auth_request
     def put(self, context):
         """Replace site context with all attributes"""
 
@@ -65,6 +73,7 @@ class SiteResource(Resource):
 
         return None, 201
 
+    @auth_request
     def patch(self, context):
         """Modify attributes of a site context"""
 
@@ -80,12 +89,14 @@ class SiteResource(Resource):
 
 
 @ns.route('/sites/<context>/<attr>')
+@ns.doc(security='apikey')
 @ns.param('context', 'The site context name')
 @ns.param('attr', 'The site attribute name')
 @ns.response(404, 'Attribute not found')
 class SiteAttrResource(Resource):
 
     @ns.doc('get_site_attr')
+    @auth_request
     def get(self, context, attr):
         """Fetch a site attribute by the given name"""
 
@@ -102,6 +113,7 @@ class SiteAttrResource(Resource):
     @ns.doc('set_site_attr')
     @ns.param('value', 'Value set to the attribute')
     @ns.response(400, 'Must specify the value in query parameter.')
+    @auth_request
     def post(self, context, attr):
         """Set a site attribute by the given name"""
 
@@ -123,6 +135,7 @@ class SiteAttrResource(Resource):
         return dict(outputs=result.output_msgs)
 
     @ns.doc('delete_site_attr')
+    @auth_request
     def delete(self, context, attr):
         """Delete a site attribute by the given name"""
 


### PR DESCRIPTION
UT as below, just use one as an example:
```
curl -X GET "http://10.6.27.1:5000/api/v2/globalconf/sites" -H  "accept: application/json" -H  "Authorization: token c997632c-7dfb-11e9-a021-0cc47aea9e02"
[
    {
        "meta": {
            "name": "clustersite"
        },
        "spec": {
            "vsftp": "n",
            "ipmitimeout": "2",
            "consoleondemand": "no",
            "enableASMI": "no",
            "ipmimaxp": "64",
            "xcatdebugmode": "1",
            "ipmiretries": "3",
            "forwarders": "10.0.0.101",
            "blademaxp": "64",
            "db2installloc": "/mntdb2",
            "domain": "pok.stglabs.ibm.com",
            "auditskipcmds": "ALL",
            "nameservers": "10.6.27.1",
            "SNsyncfiledir": "/var/xcat/syncfiles",
            "xcatiport": "3002",
            "syspowerinterval": "0",
            "ppcmaxp": "64",
            "xcatconfdir": "/etc/xcat",
            "installdir": "/install",
            "xcatdport": "3001",
            "powerinterval": "0",
            "master": "10.6.27.1",
            "auditnosyslog": "0",
            "nodesyncfiledir": "/var/xcat/node/syncfiles",
            "useNmapfromMN": "no",
            "ppcretry": "3",
            "ppctimeout": "0",
            "timezone": "America/New_York",
            "sshbetweennodes": "ALLGROUPS",
            "fsptimeout": "0",
            "tftpdir": "/tftpboot",
            "sharedtftp": "1",
            "cleanupxcatpost": "no",
            "databaseloc": "/var/lib",
            "dhcplease": "43200",
            "dnshandler": "ddns",
            "maxssh": "8",
            "dhcpinterfaces": "enP34p1s0f1:noboot,enP34p1s0f0.12"
        }
    }
]
```

Without token:
```
curl -X GET "http://10.6.27.1:5000/api/v2/globalconf/sites" -H  "accept: application/json"
{
    "message": "The server could not verify that you are authorized to access the URL requested. You either supplied the wrong credentials (e.g. a bad password), or your browser doesn't understand how to supply the credentials required."
}
```

