### PR TITLE
Make sure single ip for management node

### DIFF
--- a/travis.pl
+++ b/travis.pl
@@ -242,7 +242,7 @@ sub run_inventory_cases {
     chomp($hostname);
     print "hostname = $hostname\n";
     my $conf_file = "$ENV{'PWD'}/inventory.conf";
-    my $dstip = `hostname -i`;
+    my $dstip = `hostname -i | cut -d" " -f1`;
     chomp($dstip);
     my $cmd = "echo '[System]' > $conf_file; echo 'MN=$hostname' >> $conf_file; echo 'DSTMN'=$dstip >> $conf_file; echo '[Table_site]' >> $conf_file; echo 'key=domain' >>$conf_file; echo 'value=pok.stglabs.ibm.com' >> $conf_file";
     my @output = runcmd("$cmd");


### PR DESCRIPTION
Lately, like for #225, when Travis regression runs, the `hostname -i` returns 2 entries, and that sets `xcattest` variable `DSTMN` to be:
```
'DSTMN=127.0.0.1 127.0.1.1',
```
As a result, testcases can not deal with such setting and fail.
This PR makes sure only first entry is used for setting `DSTMN`
