### PR TITLE
Travis output improvements

### DIFF
--- a/travis.pl
+++ b/travis.pl
@@ -391,7 +391,7 @@ mark_time("install_inventory");
 print GREEN "\n------Running xcat-inventory CI cases------\n";
 $rst = run_inventory_cases();
 if($rst){
-    print RED "Run inventory cases failed\n";
+    print RED "Run xcat-inventory testcases failed\n";
     exit $rst;
 }
 mark_time("run_inventory_cases");

--- a/xcat-inventory/xcclient/inventory/backend.py
+++ b/xcat-inventory/xcclient/inventory/backend.py
@@ -43,51 +43,54 @@ class Invbackend(object):
         if not os.path.exists(cfgpath):
             raise InvalidFileException("The configuration file %s does not exist!\n"%(cfgpath))    
 
-        config = configparser.ConfigParser()
-        config.read(cfgpath)
+        configP = configparser.ConfigParser()
+        configP.read(cfgpath)
         #if not config:
         #    raise ParseException("Unable to parse configuration file %s"%(cfgpath))
-        if 'backend' not in config.sections():
-            raise ParseException("invalid configuration in %s: section \"[%s]\" not found! "%(cfgpath,'backend')) 
-        if 'InfraRepo' not in config.sections():
-            raise ParseException("invalid configuration in %s: section \"[%s]\" not found! "%(cfgpath,'InfraRepo')) 
+        if 'backend' not in configP.sections():
+            raise ParseException("%s: expected section \"[%s]\" not found! "%(cfgpath,'backend')) 
+        if 'InfraRepo' not in configP.sections():
+            raise ParseException("%s: expected section \"[%s]\" not found! "%(cfgpath,'InfraRepo')) 
 
-        if 'type' in config['backend'].keys():
-            self.bkendcfg['type']=utils.stripquotes(config['backend']['type'])
+        config = dict(configP.items('backend'))
+
+        if 'type' in config.keys():
+            self.bkendcfg['type']=utils.stripquotes(config['type'])
         else:
             self.bkendcfg['type']='git'
 
-        if 'workspace' in config['backend'].keys():
-            self.bkendcfg['workspace']=utils.stripquotes(config['backend']['workspace'])
+        if 'workspace' in config.keys():
+            self.bkendcfg['workspace']=utils.stripquotes(config['workspace'])
         else:
             self.bkendcfg['workspace']=''
 
-        if 'user' in config['backend'].keys():
-            self.bkendcfg['user']=utils.stripquotes(config['backend']['user'])
+        if 'user' in config.keys():
+            self.bkendcfg['user']=utils.stripquotes(config['user'])
         else:
             self.bkendcfg['user']="xcat"
 
-        if 'email' in config['backend'].keys():
-            self.bkendcfg['email']=utils.stripquotes(config['backend']['email'])
+        if 'email' in config.keys():
+            self.bkendcfg['email']=utils.stripquotes(config['email'])
         else: 
             self.bkendcfg['email']="xcat@xcat.org"
 
         self.bkendcfg['InfraRepo']={}
-        if 'InfraRepo' in config.keys():
-            if 'remote_repo' in config['InfraRepo'].keys(): 
-                self.bkendcfg['InfraRepo']['remote_repo']=utils.stripquotes(config['InfraRepo']['remote_repo'])
-            else:
-                self.bkendcfg['InfraRepo']['remote_repo']=""
 
-            if 'local_repo' in config['InfraRepo'].keys(): 
-                self.bkendcfg['InfraRepo']['local_repo']=utils.stripquotes(config['InfraRepo']['local_repo'])
-            else:
-                self.bkendcfg['InfraRepo']['local_repo']=utils.gethome()
+        config = dict(configP.items('InfraRepo'))
+        if 'remote_repo' in config.keys(): 
+            self.bkendcfg['InfraRepo']['remote_repo']=utils.stripquotes(config['remote_repo'])
+        else:
+            self.bkendcfg['InfraRepo']['remote_repo']=""
 
-            if 'working_dir' in config['InfraRepo'].keys(): 
-                self.bkendcfg['InfraRepo']['working_dir']=utils.stripquotes(config['InfraRepo']['working_dir'])
-            else:
-                self.bkendcfg['InfraRepo']['working_dir']='.'
+        if 'local_repo' in config.keys(): 
+            self.bkendcfg['InfraRepo']['local_repo']=utils.stripquotes(config['local_repo'])
+        else:
+            self.bkendcfg['InfraRepo']['local_repo']=utils.gethome()
+
+        if 'working_dir' in config.keys(): 
+            self.bkendcfg['InfraRepo']['working_dir']=utils.stripquotes(config['working_dir'])
+        else:
+            self.bkendcfg['InfraRepo']['working_dir']='.'
              
 
 


### PR DESCRIPTION
This PR:

* Adds small print enhancements to Travis testcase run.
* Fixed errors in `backend.py` of ` configparser` usage. Data has to be converted to dictionary before reference. It appears to have worked with older versions of Python, but now, it seems, newer version of Python is used when Travis VM is created. As a result the following testcase run errors are displayed:
```
'RUN:xcat-inventory init [Tue Aug 18 16:57:40 2020]',

          'ElapsedTime:1 sec',

          'RETURN rc = 1',

          'OUTPUT:',

          'Traceback (most recent call last):',

          '  File "/opt/xcat/lib/python/xcclient/inventory/shell.py", line 167, in main',

          '    InventoryShell(\'xcat-inventory\',\'0.1.7 (git commit 196b9ca447c77510e95c88ae544f7be146cebe46)\').run(sys.argv[1:], \'1.0\', "xCAT inventory management tool")',

          '  File "/opt/xcat/lib/python/xcclient/shell.py", line 207, in run',

          '    return args.func(args)',

          '  File "/opt/xcat/lib/python/xcclient/inventory/shell.py", line 85, in do_init',

          '    mybackend.init()',

          '  File "/opt/xcat/lib/python/xcclient/inventory/backend.py", line 109, in init',

          '    self.loadcfg(cfgpath)',

          '  File "/opt/xcat/lib/python/xcclient/inventory/backend.py", line 49, in loadcfg',

          '    for key in config[\'backend\']:',

          'AttributeError: ConfigParser instance has no attribute \'__getitem__\'',
```

After this PR, the Travis run completes with no errors.