### PR TITLE
Add Debian support to the deb build path

### DIFF
--- a/build-deb
+++ b/build-deb
@@ -9,11 +9,23 @@ printusage()
     echo "    -c : Build the xcat-inventory deb package"
 }
 # For the purpose of getting the distribution name
-if [[ ! -f /etc/lsb-release ]]; then
-    echo "ERROR: Could not find /etc/lsb-release, is this script executed on a Ubuntu machine?"
+if [[ -f /etc/os-release ]]; then
+    . /etc/os-release
+    DISTRO_ID=${ID}
+    DISTRO_VERSION=${VERSION_ID}
+elif [[ -f /etc/lsb-release ]]; then
+    . /etc/lsb-release
+    DISTRO_ID=$(echo "${DISTRIB_ID}" | tr '[:upper:]' '[:lower:]')
+    DISTRO_VERSION=${DISTRIB_RELEASE}
+else
+    echo "ERROR: Could not detect distro, is this script executed on a Ubuntu/Debian machine?"
     exit 1
 fi
-. /etc/lsb-release
+
+if [[ "${DISTRO_ID}" != "ubuntu" && "${DISTRO_ID}" != "debian" ]]; then
+    echo "ERROR: Unsupported distro ${DISTRO_ID}, this script supports Ubuntu and Debian"
+    exit 1
+fi
 # Check the necessary packages before starting the build
 declare -a packages=( "reprepro" "devscripts" "debhelper" "quilt" )
 
@@ -25,8 +37,6 @@ for package in ${packages[@]}; do
     fi
 done
 
-# Supported distributions
-dists="saucy trusty utopic xenial"
 c_flag=$1
 
 if [ -z "$c_flag" ];then

--- a/build.sh
+++ b/build.sh
@@ -25,8 +25,8 @@ case "${XCAT_BUILD_DISTRO}" in
     dftpath="/root/rpmbuild/RPMS/noarch"
     pkgtype="rpm"
     ;;
-"ubuntu")
-    buildcmd="./build-ubuntu -c" 
+"ubuntu"|"debian")
+    buildcmd="./build-deb -c"
     dftpath=$cur_path
     pkgtype="deb"
     ;;


### PR DESCRIPTION
Source /etc/os-release (with /etc/lsb-release as a fallback) so the deb build script works on Debian, where lsb-release is not installed by default. Rename build-ubuntu to build-deb to reflect that both Ubuntu and Debian are supported, and update build.sh accordingly.