### PR TITLE
Build deb against python3

### DIFF
--- a/build-deb
+++ b/build-deb
@@ -89,6 +89,15 @@ then
         VERINFO="${VERSION} (git commit $commit_id_long)"
         echo "VERINFO $VERINFO"
         packages="xcat-inventory"
+        # Rewrite python2 shebangs to python3 for the deb build only.
+        # The source keeps python2 shebangs so the rpm path (EL7) is unaffected;
+        # restored below after dpkg-buildpackage runs. Done before the VERINFO
+        # sed so the backup captures the unmodified shell.py.
+        SHEBANG_BACKUP=$(mktemp -d)
+        ( cd $curdir && tar -cf $SHEBANG_BACKUP/orig.tar $(grep -rl '^#!/usr/bin/python2' xcat-inventory) )
+        ( cd $curdir && grep -rl '^#!/usr/bin/python2' xcat-inventory \
+            | xargs sed -i '1s|^#!/usr/bin/python2$|#!/usr/bin/python3|' )
+
         cp -f $curdir/xcat-inventory/xcclient/inventory/shell.py /tmp/
         sed -i s/\#VERSION_SUBSTITUTE\#/"$VERINFO"/g $curdir/xcat-inventory/xcclient/inventory/shell.py
         target_archs=(all)
@@ -124,6 +133,10 @@ then
         if [ -f /tmp/shell.py ]; then
             cp -f /tmp/shell.py $curdir/xcat-inventory/xcclient/inventory/shell.py
             rm -f /tmp/shell.py
+        fi
+        if [ -n "$SHEBANG_BACKUP" ] && [ -f "$SHEBANG_BACKUP/orig.tar" ]; then
+            ( cd $curdir && tar -xf $SHEBANG_BACKUP/orig.tar )
+            rm -rf "$SHEBANG_BACKUP"
         fi
     fi
 

--- a/xcat-inventory/debian/control
+++ b/xcat-inventory/debian/control
@@ -8,5 +8,5 @@ Homepage: https://xcat.org/
 
 Package: xcat-inventory
 Architecture: all
-Depends: python-pymysql,python-sqlalchemy,python-psycopg2,python-six,python-yaml,python-jinja2,git
+Depends: python3-pymysql,python3-sqlalchemy,python3-psycopg2,python3-six,python3-yaml,python3-jinja2,python3-sh,python3-deepdiff,git
 Description: xcat inventory


### PR DESCRIPTION
Make the .deb installable on modern Debian/Ubuntu where python2 packages are no longer available.

- Switch `debian/control` Depends to python3-* packages (including `python3-sh` and `python3-deepdiff` for the `sh` and `deepdiff` imports in `backend.py` and `structurediff.py`).
- Have `build-deb` rewrite `python2` shebangs to `python3` at deb-build time only; the source tree keeps `python2` shebangs so the rpm/EL7 path (which still targets python2) is unaffected.