### PR TITLE
Add Python 3.12+ and SQLAlchemy 2.x compatibility

### DIFF
--- a/xcat-inventory/xcclient/inventory/dbobject.py
+++ b/xcat-inventory/xcclient/inventory/dbobject.py
@@ -62,9 +62,8 @@ class mixin(object):
 ########################################################################
 class passwd(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('passwd')
     __tablename__ = 'passwd'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('passwd'))
 
     @classmethod
     def primkeys(cls):
@@ -77,9 +76,8 @@ class passwd(Base,mixin):
 ########################################################################
 class networks(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('networks')
     __tablename__ = 'networks'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('networks'))
 
     @classmethod
     def primkeys(cls):
@@ -105,38 +103,34 @@ class networks(Base,mixin):
 ########################################################################
 class routes(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('routes')
     __tablename__ = 'routes'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('routes'))
 
 
 ########################################################################
 class nodetype(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('nodetype')
     __tablename__ = 'nodetype'
-    __table_args__ = {'autoload':True} 
+    __table_args__ = autoload_kwargs(DBsession.getEngine('nodetype'))
 
 ########################################################################
 '''
 class hosts(Base,mixin):
     """"""
     __tablename__ = 'hosts'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('hosts'))
 '''
 ########################################################################
 class noderes(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('noderes')
     __tablename__ = 'noderes'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('noderes'))
 
 ########################################################################
 class switch(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('switch')
     __tablename__ = 'switch'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('switch'))
 
     @classmethod
     def getobjkey(cls):
@@ -144,29 +138,25 @@ class switch(Base,mixin):
 ########################################################################
 class switches(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('switches')
     __tablename__ = 'switches'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('switches'))
 
 
 ########################################################################
 class mac(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('mac')
     __tablename__ = 'mac'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('mac'))
 ########################################################################
 class hwinv(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('hwinv')
     __tablename__ = 'hwinv'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('hwinv'))
 ########################################################################
 class postscripts(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('postscripts')
     __tablename__ = 'postscripts'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('postscripts'))
 
     @classmethod
     def getReservedKeys(self):
@@ -175,78 +165,66 @@ class postscripts(Base,mixin):
 ########################################################################
 class bootparams(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('bootparams')
     __tablename__ = 'bootparams'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('bootparams'))
 
 ########################################################################
 class nodelist(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('nodelist')
     __tablename__ = 'nodelist'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('nodelist'))
 
 ########################################################################
 class vm(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('vm')
     __tablename__ = 'vm'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('vm'))
 ########################################################################
 class policy(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('policy')
     __tablename__ = 'policy'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('policy'))
 
 ########################################################################
 class nodehm(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('nodehm')
     __tablename__ = 'nodehm'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('nodehm'))
 ########################################################################
 class nodegroup(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('nodegroup')
     __tablename__ = 'nodegroup'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('nodegroup'))
 ########################################################################
 class vpd(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('vpd')
     __tablename__ = 'vpd'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('vpd'))
 ########################################################################
 class servicenode(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('servicenode')
     __tablename__ = 'servicenode'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('servicenode'))
 ########################################################################
 class hosts(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('hosts')
     __tablename__ = 'hosts'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('hosts'))
 ########################################################################
 class nics(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('nics')
     __tablename__ = 'nics'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('nics'))
 ########################################################################
 class openbmc(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('openbmc')
     __tablename__ = 'openbmc'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('openbmc'))
 ########################################################################
 class prodkey(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('prodkey')
     __tablename__ = 'prodkey'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('prodkey'))
 
     @classmethod
     def getobjkey(cls):
@@ -254,99 +232,83 @@ class prodkey(Base,mixin):
 ########################################################################
 class domain(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('domain')
     __tablename__ = 'domain'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('domain'))
 ########################################################################
 class chain(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('chain')
     __tablename__ = 'chain'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('chain'))
 ########################################################################
 class rack(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('rack')
     __tablename__ = 'rack'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('rack'))
 ########################################################################
 class nodepos(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('nodepos')
     __tablename__ = 'nodepos'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('nodepos'))
 ########################################################################
 class ppc(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('ppc')
     __tablename__ = 'ppc'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('ppc'))
 ########################################################################
 class ppchcp(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('ppchcp')
     __tablename__ = 'ppchcp'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('ppchcp'))
 ########################################################################
 class mp(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('mp')
     __tablename__ = 'mp'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('mp'))
 ########################################################################
 class zvm(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('zvm')
     __tablename__ = 'zvm'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('zvm'))
 ########################################################################
 class mpa(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('mpa')
     __tablename__ = 'mpa'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('mpa'))
 ########################################################################
 class pdu(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('pdu')
     __tablename__ = 'pdu'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('pdu'))
 ########################################################################
 class pduoutlet(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('pduoutlet')
     __tablename__ = 'pduoutlet'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('pduoutlet'))
 ########################################################################
 class cfgmgt(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('cfgmgt')
     __tablename__ = 'cfgmgt'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('cfgmgt'))
 ########################################################################
 class hypervisor(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('hypervisor')
     __tablename__ = 'hypervisor'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('hypervisor'))
 ########################################################################
 class iscsi(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('iscsi')
     __tablename__ = 'iscsi'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('iscsi'))
 ########################################################################
 class mic(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('mic')
     __tablename__ = 'mic'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('mic'))
 ########################################################################
 class ppcdirect(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('ppcdirect')
     __tablename__ = 'ppcdirect'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('ppcdirect'))
 
     @classmethod
     def primkeys(cls):
@@ -354,69 +316,58 @@ class ppcdirect(Base,mixin):
 ########################################################################
 class storage(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('storage')
     __tablename__ = 'storage'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('storage'))
 ########################################################################
 class websrv(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('websrv')
     __tablename__ = 'websrv'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('websrv'))
 ########################################################################
 class prescripts(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('prescripts')
     __tablename__ = 'prescripts'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('prescripts'))
 ########################################################################
 class ipmi(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('ipmi')
     __tablename__ = 'ipmi'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('ipmi'))
 ########################################################################
 class osimage(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('osimage')
     __tablename__ = 'osimage'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('osimage'))
 ########################################################################
 class linuximage(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('linuximage')
     __tablename__ = 'linuximage'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('linuximage'))
 ########################################################################
 class winimage(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('winimage')
     __tablename__ = 'winimage'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('winimage'))
 ########################################################################
 class nimimage(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('nimimage')
     __tablename__ = 'nimimage'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('nimimage'))
 ########################################################################
 class zone(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('zone')
     __tablename__ = 'zone'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('zone'))
 ########################################################################
 class osdistro(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('osdistro')
     __tablename__ = 'osdistro'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('osdistro'))
 ########################################################################
 class site(Base,mixin):
     """"""
-    Base.metadata.bind = DBsession.getEngine('site')
     __tablename__ = 'site'
-    __table_args__ = {'autoload':True}
+    __table_args__ = autoload_kwargs(DBsession.getEngine('site'))
 ########################################################################
     def getdict(self):
         mydict={}

--- a/xcat-inventory/xcclient/inventory/dbsession.py
+++ b/xcat-inventory/xcclient/inventory/dbsession.py
@@ -5,6 +5,7 @@
 # -*- coding: utf-8 -*-
 #
 
+import sqlalchemy
 from sqlalchemy import create_engine,inspect
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
@@ -18,7 +19,15 @@ from .exceptions import *
 codecs.register(lambda name: codecs.lookup('utf8') if name == 'utf8mb4' else None)
 
 Base = declarative_base()
-Base.metadata.bind = None;
+
+# SQLAlchemy 0.9/1.0/1.3 require autoload=True to trigger reflection even when
+# autoload_with is set; 1.4+ make autoload=True implicit; 2.0 removed autoload.
+# This helper returns the right __table_args__ kwargs across all versions.
+_sqla_major = int(sqlalchemy.__version__.split('.')[0])
+def autoload_kwargs(engine):
+    if _sqla_major < 2:
+        return {'autoload': True, 'autoload_with': engine}
+    return {'autoload_with': engine}
 
 
 class Singleton(object):
@@ -29,7 +38,8 @@ class Singleton(object):
 
 class DBsession(Singleton):
     _dbcfgpath='/etc/xcat/cfgloc'
-    _dbcfgregex=re.compile("^(\S+):dbname=(\S+);host=(\S+)\|(\S+)\|(\S*)$")
+    _dbcfgregex=re.compile(r"^(\S+):dbname=(\S+);host=(\S+)\|(\S+)\|(\S*)$")
+    _engine=None
 
     def __init__(self):
         self._sessions={}
@@ -72,13 +82,11 @@ class DBsession(Singleton):
     def getEngine(cls,tablename=None):
         """"""
         if not cls.isSqlite():
-            if not Base.metadata.bind:
-                engine=cls.createEngine()
-            else:
-                return Base.metadata.bind
+            if cls._engine is None:
+                cls._engine=cls.createEngine()
+            return cls._engine
         elif tablename:
-            engine=cls.createEngine(tablename)
-        return engine
+            return cls.createEngine(tablename)
 
     #bind Base.metadata to db engine
     @classmethod

--- a/xcat-inventory/xcclient/inventory/utils.py
+++ b/xcat-inventory/xcclient/inventory/utils.py
@@ -73,7 +73,7 @@ def Util_subvarsindict(mydict,vardict):
 def Util_getdictval(mydict,keystr):
     if not  isinstance(mydict,dict):
         return None
-    dictkeyregex=re.compile("([^\.]+)\.?(\S+)*")
+    dictkeyregex=re.compile(r"([^\.]+)\.?(\S+)*")
     result=re.findall(dictkeyregex,keystr)
     if result:
         (key,remdkey)=result[0]
@@ -86,7 +86,7 @@ def Util_getdictval(mydict,keystr):
 
 # get the dict value mydict[a][b][c] with key path a.b.c
 def Util_setdictval(mydict,keystr,value):
-    dictkeyregex=re.compile("([^\.]+)\.?(\S+)*")
+    dictkeyregex=re.compile(r"([^\.]+)\.?(\S+)*")
     result=re.findall(dictkeyregex,keystr)
     if result:
         (key,remdkey)=result[0]
@@ -99,7 +99,7 @@ def Util_setdictval(mydict,keystr,value):
 
 #remove dict key [a][b][c] with key path a.b.c
 def Util_deldictkey(mydict,keystr):
-    dictkeyregex=re.compile("([^\.]+)\.?(\S+)*")
+    dictkeyregex=re.compile(r"([^\.]+)\.?(\S+)*")
     result=re.findall(dictkeyregex,keystr)
     if result:
         (key,remdkey)=result[0]

--- a/xcat-inventory/xcclient/inventory/vutil.py
+++ b/xcat-inventory/xcclient/inventory/vutil.py
@@ -14,7 +14,7 @@ from distutils.version import LooseVersion, StrictVersion
 from . import globalvars
 
 def isIPaddr(varin):
-    ValidIpAddressRegex = "^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.(([0-9]|[0-9]{2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){2}([0-9]|[0-9]{2}|0[0-9]{2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])$";
+    ValidIpAddressRegex = r"^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.(([0-9]|[0-9]{2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){2}([0-9]|[0-9]{2}|0[0-9]{2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])$";
     return (re.match(ValidIpAddressRegex,str(varin)) is not None)
 
 def isMac(varin):

--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -43,13 +43,13 @@ class XcatBase(object):
 
     @classmethod
     def __gendepdict(cls,schmpath):
-        valregex=re.compile("^\$\{\{((.*):(.*))\}\}\s*$")
-        revregex=re.compile("^W:T\{(\S+)\}=(.+)$")
-        validateregex=re.compile("^C:(.+)$")
-        tabentregex=re.compile("T\{(.*?)\}")
-        dictvalregex=re.compile("V\{(.*?)\}")
-        filevalregex=re.compile("^F:(.+)$")
-        refregex=re.compile("^REF\{(.+)\}$")
+        valregex=re.compile(r"^\$\{\{((.*):(.*))\}\}\s*$")
+        revregex=re.compile(r"^W:T\{(\S+)\}=(.+)$")
+        validateregex=re.compile(r"^C:(.+)$")
+        tabentregex=re.compile(r"T\{(.*?)\}")
+        dictvalregex=re.compile(r"V\{(.*?)\}")
+        filevalregex=re.compile(r"^F:(.+)$")
+        refregex=re.compile(r"^REF\{(.+)\}$")
  
         def __parselambda(expression):
             mtchdval=re.findall(valregex,expression)
@@ -325,7 +325,7 @@ class XcatBase(object):
             elif type(criteria) == list:
                 criterialist=criteria
             for expression in criterialist:
-                validateregex=re.compile("^C:\$\{\{(.+)\}\}$")
+                validateregex=re.compile(r"^C:\$\{\{(.+)\}\}$")
                 mtchdval=re.findall(validateregex,expression)
                 rule=mtchdval[0]
 


### PR DESCRIPTION
Make `xcat-inventory` work on modern Python/SQLAlchemy without breaking the SQLA 1.x / Python 2.x path used by the rpm/EL7 build.

- SQLA 2.x port: replace the SQLA 1.x `autoload=True` + `metadata.bind` pattern with an `autoload_kwargs()` helper (selects `autoload=True` + `autoload_with` for SQLA <2.0, `autoload_with` alone for 2.0+), and replace the `metadata.bind` engine cache with a class-level cache in `DBsession`.
- Regex string literals (`\S`, `\.`, `\$`, etc.) are now raw strings to silence Python 3.12+ SyntaxWarnings on unrecognized escapes. Raw strings work identically on Python 2.0+ and 3.0+.