### PR TITLE
build.sh: check PIPESTATUS to detect build failures

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ case "${XCAT_BUILD_DISTRO}" in
 esac
 
 $buildcmd |& tee /tmp/build.log
-if [ $? != 0 ]; then
+if [ ${PIPESTATUS[0]} != 0 ]; then
     echo "[ERROR] Failed to build $pkgname by command $buildcmd"
     exit 1
 fi


### PR DESCRIPTION
The previous `$?` check read `tee`'s exit code instead of the build command's. Use `PIPESTATUS[0]` instead.