### PR TITLE
Escape backslashes in T{} substitutions to silence SyntaxWarnings on Python 3.12+

### DIFF
--- a/xcat-inventory/xcclient/inventory/xcatobj.py
+++ b/xcat-inventory/xcclient/inventory/xcatobj.py
@@ -225,15 +225,15 @@ class XcatBase(object):
                 tabval=self._dbhash[item]
             else:
                 tabval=self.__evalschema_tab(item) 
-            myexpression=myexpression.replace('T{'+item+'}',"'"+str(tabval).replace("'","\\'")+"'")   
+            myexpression=myexpression.replace('T{'+item+'}',"'"+str(tabval).replace("\\","\\\\").replace("'","\\'")+"'")   
         tabmatched=re.findall(r'T\{(\S+)\}',myexpression)
         if tabmatched:
             for item in tabmatched:
                 if myschmpath: 
-                    myexpression=myexpression.replace('T{'+item+'}',"'"+str(item).replace("'","\\'")+"'")
+                    myexpression=myexpression.replace('T{'+item+'}',"'"+str(item).replace("\\","\\\\").replace("'","\\'")+"'")
                 else:
                     tabval=self.__evalschema_tab(item)
-                    myexpression=myexpression.replace('T{'+item+'}',"'"+str(tabval).replace("'","\\'")+"'")
+                    myexpression=myexpression.replace('T{'+item+'}',"'"+str(tabval).replace("\\","\\\\").replace("'","\\'")+"'")
         evalexp=eval("lambda "+myexpression,None,ctxdict)
         result=evalexp()
         if myschmpath:
@@ -261,7 +261,7 @@ class XcatBase(object):
                 tabval=self._dbhash[item]
             if tabval is None:
                 tabval=''
-            myexpression=myexpression.replace('T{'+item+'}',"'"+str(tabval).replace("'","\\'")+"'")
+            myexpression=myexpression.replace('T{'+item+'}',"'"+str(tabval).replace("\\","\\\\").replace("'","\\'")+"'")
         ctxdict={} 
         for item in mydepvallist:
             myval=Util_getdictval(self._mydict,item)


### PR DESCRIPTION
T{tablename.column} placeholders in schema rules are replaced with DB values before being eval()'d. Backslashes in those values were inserted as-is, so a DB value like \d+ produced SyntaxWarnings during export on Python 3.12+. Escaping the backslash yields the same Python string at runtime; EL7's Python 2.7 is unaffected.